### PR TITLE
feat(skills): add synology-nas Agent Skill (closes #5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Skill development workspace (eval runs, logs, candidate artifacts)
+skills/*-workspace/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- `synology-nas` Anthropic Agent Skill at `skills/synology-nas/` — teaches Claude how to use the MCP tools effectively (multi-NAS targeting, aggregate health checks, path conventions, per-domain workflows for files/downloads/health/NFS/users). Works in Claude Code, Claude Desktop, and claude.ai. Closes #5.
+
 ## [1.1.0] - 2025-06-07
 
 # 🚀 Synology MCP Server v1.1.0 - Xiaozhi WebSocket & Enhanced Docker Support

--- a/README.md
+++ b/README.md
@@ -300,6 +300,19 @@ docker-compose up
 - **`synology_nfs_list_shares`** - List all shared folders with their NFS permissions
 - **`synology_nfs_set_permission`** - Set NFS client access permissions on a shared folder
 
+## 🧠 Claude Code / Claude.ai Skill
+
+For Claude Code, Claude Desktop, and claude.ai users, this repo ships an Anthropic Agent Skill that teaches Claude how to use the MCP tools effectively — picking the right tool, targeting the right NAS in multi-NAS setups, preferring aggregate health checks over fan-out calls, and using correct path conventions.
+
+The skill lives at [`skills/synology-nas/`](skills/synology-nas/) and uses progressive disclosure across six domains (auth, files, downloads, health, shares/NFS, user management).
+
+**Install:**
+
+- **Claude Code**: copy or symlink the folder into `~/.claude/skills/synology-nas/`
+- **Claude.ai / Claude Desktop**: upload the `synology-nas/` folder via the Skills settings page
+
+The skill is purely additive — it works alongside the MCP and only triggers on Synology/NAS-related prompts.
+
 ## ⚙️ Configuration Options
 
 > **⚠️ Security Warning: Use a Dedicated Account**

--- a/skills/synology-nas/SKILL.md
+++ b/skills/synology-nas/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: synology-nas
+description: Use this skill for ANY task on a Synology NAS via the mcp-server-synology MCP — managing files and folders on the NAS, searching NAS shares, reading or creating NAS files, running Download Station tasks (torrents, magnets, downloads), checking NAS health (disks, SMART, volumes, RAID, SHR, UPS, CPU/memory utilization), creating shared folders, configuring NFS exports, and managing NAS users, groups, or share permissions. Triggers on "synology", "NAS", "DSM", "DiskStation", "DS220+/DS920+/etc", "Download Station", "/volume1", and any NAS-share path. Use even when the user just says "my NAS" or names a model number without saying "Synology". Distinct from the lifehacker-cert skill, which only handles SSL certs on one specific NAS — this skill is for general NAS operation.
+---
+
+# Synology NAS
+
+This skill teaches you how to use the `mcp-server-synology` MCP effectively. The MCP exposes ~50 tools across six domains; the trick is picking the right tool, targeting the right NAS, and not exploding a single user request into a dozen redundant calls.
+
+## Mental model
+
+Three things shape almost every interaction:
+
+1. **Targeting** — most setups have one NAS and you can omit the target argument. Multi-NAS setups require a `nas_name` (or `base_url`) on every tool call. Don't guess; discover first.
+2. **State** — auth is session-based and usually auto-managed. You almost never need to call `synology_login` yourself. Check status first; only log in if status says you must.
+3. **Aggregation** — several individual tools have a *_summary equivalent. When the user wants a "checkup" or "overview," reach for the aggregate. When they want a specific number, use the targeted tool.
+
+Once those three are settled, the rest is picking the right domain.
+
+## Always start here
+
+Before any operation, run discovery — it's two cheap calls and answers "which NAS?" and "am I logged in?":
+
+1. `synology_list_nas` — lists configured NAS units with names, URLs, connection status.
+2. `synology_status` — shows which sessions are active.
+
+If the user mentions a NAS by name (e.g. "the backup NAS", "nas2"), match it to a `nas_name` from `synology_list_nas`. If only one NAS is configured, you can omit `nas_name` on subsequent calls. If multiple are configured and the user is ambiguous, ask which one — don't pick.
+
+## Tool call shape
+
+Every operational tool accepts an optional target argument:
+
+- `nas_name` (preferred) — the identifier from settings.json, e.g. `"nas1"`.
+- `base_url` — fallback when the NAS isn't in settings.json.
+
+Pass at most one. Omit both only when there's a single NAS configured.
+
+Path arguments **must start with `/`**. User-facing data lives under `/volume1/` (or `/volume2/`, etc., for additional volumes). The root `/` lists shares; `/homes`, `/photo`, `/video` etc. are share-level mount points underneath. Don't invent paths — list the parent first if unsure.
+
+## Domain map
+
+When the user asks about… → read…
+
+| User says | Domain | Reference |
+|-----------|--------|-----------|
+| login, logout, session, "who's logged in", multi-NAS, settings.json | auth | [references/auth.md](references/auth.md) |
+| list/find/search files, read/create/delete/move/rename files & folders, shares | filestation | [references/files.md](references/files.md) |
+| download, torrent, magnet, BT, transmission-style task | Download Station | [references/downloads.md](references/downloads.md) |
+| disks, SMART, RAID/SHR, volume, UPS, CPU/memory utilization, system info, "is the NAS healthy" | health | [references/health.md](references/health.md) |
+| NFS, share permissions, "let host X mount", create share | shares & NFS | [references/shares-nfs.md](references/shares-nfs.md) |
+| users, groups, permissions, "add user", "remove from group" | user management | [references/users.md](references/users.md) |
+
+Read the reference for a domain before doing non-trivial work in it. Each reference covers the tool list, the right call ordering, and known gotchas. Don't read every reference — only the ones you need.
+
+## Cross-cutting patterns
+
+### Prefer aggregate tools for overviews
+
+If the user asks "is the NAS healthy?" or "give me a system report," call `synology_health_summary` once instead of fanning out to `synology_system_info` + `synology_utilization` + `synology_disk_health` + `synology_volume_status`. The summary is one round-trip and returns the same data. Reach for the individual tools only when the user wants one specific reading (e.g. "what's the CPU at right now?").
+
+### Read-only first
+
+When in doubt about a destructive action, list/inspect first:
+
+- Before `delete`: `get_file_info` to confirm the path resolves to what you think.
+- Before `ds_delete_tasks`: `ds_list_tasks` to confirm the IDs.
+- Before `synology_delete_user`: `synology_get_user` to confirm the account.
+
+This is a real NAS with real data — there is no "undo" for these tools.
+
+### Don't paginate without need
+
+Tools that accept `offset`/`limit` (e.g. `ds_list_tasks`, `search_files`) default to sensible values. Don't add pagination unless the user mentions a large dataset or a previous call returned suspiciously few results.
+
+### Trust auto-login
+
+Auto-login is on by default — the server logs in to every configured NAS at startup. You should expect operational tools to "just work" without calling `synology_login` first. If a tool returns an auth error, *then* call `synology_status` to diagnose, and only call `synology_login` if no session is active. See [references/auth.md](references/auth.md) for the full state machine.
+
+### Multi-step workflows: minimize round-trips
+
+If the user says "list shares and then list the photos folder," do those two calls — don't preface them with a discovery dance. Discovery (`synology_list_nas`/`synology_status`) is for when targeting or auth is genuinely unclear, not as a ritual before every request.
+
+## Anti-patterns to avoid
+
+- **Calling `synology_login` reflexively.** Auto-login almost always handled it.
+- **Fanning out to 4 health tools when the user asked "how's the NAS doing?"** Use `synology_health_summary`.
+- **Inventing paths like `/Documents/foo` or `~/photos`.** Real paths start with `/volume1/`. List the parent if unsure.
+- **Picking a NAS in a multi-NAS setup without confirmation.** Ask which one.
+- **Confusing "shares" with "files."** A *share* is the top-level mount (Photos, video, homes); creating one is an admin action and lives in `synology_create_share` (see shares-nfs.md). Creating a *folder under* a share is `create_directory`.
+- **Bulk operations without verification.** If the user asks to delete "all old downloads," list them, summarize what you're about to delete, and confirm before calling `ds_delete_tasks` or `delete`.
+
+## Example: a typical session
+
+User says: "Check on my NAS — anything I should worry about?"
+
+Good response:
+1. `synology_list_nas` → confirm which NAS (or that there's only one).
+2. `synology_health_summary` → one call, full picture.
+3. Read the result, surface anything red (degraded volumes, failing disks, high temps), and tell the user.
+
+Avoid:
+1. `synology_login` (unnecessary).
+2. `synology_system_info`, then `synology_utilization`, then `synology_disk_health`, then `synology_volume_status` (4 calls when 1 suffices).
+
+## When tool descriptions disagree with this skill
+
+The MCP's own tool descriptions sometimes say "from secrets.json" — settings actually live at `~/.config/synology-mcp/settings.json`. Trust this skill over those stale strings. If the user reports an actual auth/config bug, point them at the project README's "Configuration Options" section and don't try to "fix" it from inside Claude.

--- a/skills/synology-nas/evals/evals.json
+++ b/skills/synology-nas/evals/evals.json
@@ -1,0 +1,49 @@
+{
+  "skill_name": "synology-nas",
+  "evals": [
+    {
+      "id": 0,
+      "name": "health-aggregate-vs-fanout",
+      "prompt": "ok i wanna do a quick health check on my synology, just tell me if anything's off — disks, volumes, that kind of thing. before you actually call anything, just give me the plan: which mcp tools you'd call, in what order, and why. don't worry about generating fake output, just walk me through your approach.",
+      "expected_output": "A plan that calls synology_health_summary once (the aggregate tool) rather than fanning out to synology_system_info + synology_utilization + synology_disk_health + synology_volume_status. The plan should mention drilling in with synology_disk_smart only if a specific disk shows warnings.",
+      "files": [],
+      "assertions": [
+        {"text": "Plan calls synology_health_summary as the primary discovery step (rather than fanning out to multiple individual health tools)"},
+        {"text": "Plan does NOT call all four of synology_system_info, synology_utilization, synology_disk_health, synology_volume_status individually as the default approach"},
+        {"text": "Plan mentions drilling into synology_disk_smart only conditionally — if disk_health shows a warning"},
+        {"text": "Plan does NOT include a reflexive synology_login call — trusts auto-login"},
+        {"text": "Plan handles the multi-NAS case by checking synology_list_nas (or noting the assumption that there's only one NAS)"}
+      ]
+    },
+    {
+      "id": 1,
+      "name": "discovery-paths-multinas",
+      "prompt": "hey i've got two synology NASes set up at home — primary and backup — and i honestly can't remember which one has my photo library. i need to find any .raw files in the photos folder, wherever they are. give me your plan first: which tools, what arguments, what order, and how you'd handle the 'which NAS' question.",
+      "expected_output": "A plan that calls synology_list_nas first to enumerate, then either asks the user which NAS or searches both. Uses search_files with a path like /Photos or /volume1/Photos and pattern *.raw. Does not invent paths like ~/photos or /photos (lowercase) without justification.",
+      "files": [],
+      "assertions": [
+        {"text": "Plan starts with synology_list_nas to enumerate configured NAS units"},
+        {"text": "Plan addresses the multi-NAS ambiguity (either asks the user, or proposes searching both)"},
+        {"text": "Plan uses search_files (not list_directory + manual filtering)"},
+        {"text": "Plan uses an absolute path starting with / for the search target (e.g., /Photos or /volume1/Photos), not ~/photos or relative paths"},
+        {"text": "Plan passes nas_name explicitly when targeting a specific NAS in a multi-NAS setup"},
+        {"text": "Plan does NOT call synology_login as a precondition (auto-login handles it)"}
+      ]
+    },
+    {
+      "id": 2,
+      "name": "downloads-cleanup-safety",
+      "prompt": "my download station has a ton of finished torrents cluttering it up. nuke em. plan first — what's the order of operations, what flags do you set, and what should i be aware of before you actually delete anything?",
+      "expected_output": "A plan that calls ds_list_tasks first to identify finished/seeding tasks, summarizes what would be deleted, and only then calls ds_delete_tasks with force_complete=true. The plan should warn that deletion is permanent and that files on disk are kept by default (the task entry disappears but downloaded files remain unless separately deleted).",
+      "files": [],
+      "assertions": [
+        {"text": "Plan calls ds_list_tasks before ds_delete_tasks (read-before-mutate)"},
+        {"text": "Plan filters for finished/seeding tasks rather than deleting all tasks indiscriminately"},
+        {"text": "Plan uses force_complete=true (or notes that flag is needed for finished/seeding tasks)"},
+        {"text": "Plan warns the user that ds_delete_tasks is permanent — no recycle bin for tasks"},
+        {"text": "Plan distinguishes between deleting the task entry and deleting the downloaded files on disk (mentions that files stay unless separately removed via the delete tool)"},
+        {"text": "Plan offers a confirmation step / summary before bulk deletion rather than acting blindly"}
+      ]
+    }
+  ]
+}

--- a/skills/synology-nas/references/auth.md
+++ b/skills/synology-nas/references/auth.md
@@ -1,0 +1,85 @@
+# Auth & multi-NAS targeting
+
+## Tools
+
+| Tool | What it does |
+|------|--------------|
+| `synology_status` | Show which sessions are active across all configured NAS units |
+| `synology_list_nas` | List configured NAS units (name, URL, connection status) |
+| `synology_login` | Manually log in to a NAS — only needed when auto-login is off or has failed |
+| `synology_logout` | End a session — almost never needed in normal use |
+
+## The auth state machine
+
+The MCP server logs in automatically at startup for every NAS configured in `~/.config/synology-mcp/settings.json` (or the legacy `.env`). Sessions persist for the server's lifetime. So:
+
+- **Default state**: every configured NAS is already authenticated. You can call file/download/health tools immediately.
+- **If a tool returns an auth error**: call `synology_status` to see what's wrong. The session may have timed out or the credentials may be invalid.
+- **If status confirms no active session**: then — and only then — call `synology_login` with the relevant `nas_name`.
+
+Don't preface a workflow with `synology_login`. It's noise 99% of the time and confuses users who expect the server to "just be connected."
+
+## Multi-NAS targeting
+
+Every operational tool accepts:
+
+- `nas_name` — the identifier from settings.json (e.g., `"nas1"`, `"backup"`). Preferred.
+- `base_url` — full URL like `"http://192.168.1.100:5000"`. Fallback when the NAS isn't configured.
+
+### Picking a target
+
+1. Call `synology_list_nas` to see what's configured.
+2. If the user named a NAS by note/identifier, match it to a `nas_name`.
+3. If only one NAS is configured, you can omit the target argument entirely.
+4. If multiple are configured and the user is ambiguous, **ask** which one. Don't guess based on alphabetical order or "the first one".
+
+### When to use base_url instead
+
+`base_url` is for one-off connections to a NAS that isn't in settings.json — e.g., the user is testing a new device or troubleshooting from a different network. For everything else, prefer `nas_name`: it's shorter, picks up credentials automatically, and survives IP changes.
+
+## settings.json — what to know
+
+Lives at `~/.config/synology-mcp/settings.json` (XDG standard). The file requires `chmod 600` permissions; the server will refuse to load it otherwise. Schema (abridged):
+
+```json
+{
+  "synology": {
+    "nas1": { "host": "192.168.1.100", "port": 5000, "username": "...", "password": "...", "note": "Primary" },
+    "nas2": { "host": "192.168.1.200", "port": 5001, "username": "...", "password": "...", "note": "Backup" }
+  }
+}
+```
+
+Port 5001 enables HTTPS; anything else uses HTTP. The `note` is for the user's reference — surface it when listing NAS units to a user, since human-readable notes ("primary", "backup") are easier to reason about than `nas1`/`nas2`.
+
+## Gotchas
+
+- **2FA**: the server can't handle 2FA prompts. If a NAS is configured with 2FA on the account, login will hang or fail. Tell the user to use a dedicated, non-admin account without 2FA for the MCP. Don't try to work around it.
+- **Session expiry**: long-idle sessions can be invalidated by DSM. If a tool returns a session error, re-running after a `synology_login` usually fixes it. Don't loop on retry — diagnose with `synology_status` first.
+- **Stale `secrets.json` references**: some tool descriptions still say "from secrets.json". The actual file is `settings.json`. This is a docs bug in the MCP, not a config you need to recreate.
+
+## Workflow examples
+
+### "Am I connected?"
+
+```
+synology_status
+```
+
+Returns connection state for each configured NAS. If everything is green, you're done.
+
+### "List my NASes"
+
+```
+synology_list_nas
+```
+
+Returns names, URLs, notes, and connection status. Surface the `note` field to the user — it's the human label.
+
+### "Log out of nas2"
+
+```
+synology_logout(nas_name="nas2")
+```
+
+Almost never needed in normal use, but available for cleanup or when rotating credentials.

--- a/skills/synology-nas/references/downloads.md
+++ b/skills/synology-nas/references/downloads.md
@@ -1,0 +1,83 @@
+# Download Station
+
+## Tools
+
+| Tool | Purpose | Required |
+|------|---------|----------|
+| `ds_get_info` | Service info (version, total tasks, settings) | — |
+| `ds_list_tasks` | List download tasks with status | — (optional `offset`, `limit`) |
+| `ds_create_task` | Add a new task (HTTP, magnet, torrent URL) | `uri` |
+| `ds_pause_tasks` | Pause one or more tasks | `task_ids` |
+| `ds_resume_tasks` | Resume paused tasks | `task_ids` |
+| `ds_delete_tasks` | Remove tasks | `task_ids` |
+| `ds_get_statistics` | Current up/down throughput | — |
+| `ds_list_downloaded_files` | Files completed by Download Station | — |
+
+All accept `nas_name` / `base_url` for targeting.
+
+## Task lifecycle
+
+1. **Create** — `ds_create_task` with a URI (HTTP URL, magnet link, `https://…/foo.torrent`). Optionally specify `destination` (a folder path under `/volume1/`).
+2. **List** — `ds_list_tasks` returns IDs (`dbid_123`), titles, sizes, progress, status (`downloading`, `paused`, `seeding`, `error`, `finished`).
+3. **Manage** — pause/resume/delete by ID.
+4. **Stats** — `ds_get_statistics` for current bandwidth; `ds_get_info` for total throughput counters.
+
+## Workflow patterns
+
+### Always list before mutating
+
+If the user says "pause the big one" or "remove the failed downloads," call `ds_list_tasks` first, identify the IDs, summarize what you'll do, and confirm. Don't act on guessed IDs.
+
+### Cleaning up completed tasks
+
+`ds_delete_tasks` accepts `force_complete: true` to clean out finished/seeding tasks. Without it, finished tasks may need to stop seeding first. Surface this distinction to the user — "delete and stop seeding" vs. "remove from the list".
+
+### Magnet links
+
+Magnet URIs work as-is. Just paste the full `magnet:?xt=urn:btih:…` string into `uri`. No special handling needed.
+
+### Default destination
+
+If `destination` is omitted, Download Station uses its configured default (typically `/volume1/downloads` or whatever the user set in DSM). Don't override unless the user specified a path.
+
+## Gotchas
+
+- **Task IDs are strings**, not numbers. They look like `dbid_123` or `dbid_abc`. Pass them as JSON strings in the `task_ids` array.
+- **`ds_delete_tasks` is permanent**. There's no recycle bin for tasks. Confirm before bulk delete, especially if any tasks have local files the user might want to keep.
+- **Deleting a task ≠ deleting its files.** By default DSM keeps the downloaded files; the task entry just disappears. If the user wants files gone too, they need to also `delete` the file paths.
+- **Magnet hash → torrent**: it can take 10–60s for DSM to fetch metadata for a magnet. A freshly-created magnet task will show progress 0% with no size for a bit — that's normal, don't report it as "stuck".
+- **Authentication required for some sources**: HTTP downloads from sites needing login may fail silently. Check `ds_list_tasks` for `status: "error"`.
+
+## Examples
+
+### "Download this torrent"
+
+```
+ds_create_task(uri="magnet:?xt=urn:btih:abc...", destination="/volume1/downloads/movies")
+```
+
+### "What's downloading right now?"
+
+```
+ds_list_tasks
+```
+
+Filter by `status` in your summary — focus on `downloading` and `error`, not the full list.
+
+### "Pause everything"
+
+```
+ds_list_tasks  # get IDs first
+ds_pause_tasks(task_ids=["dbid_1", "dbid_2", ...])
+```
+
+Pause is idempotent — pausing an already-paused task is fine.
+
+### "Clean up finished downloads"
+
+```
+ds_list_tasks  # find tasks with status "finished" or "seeding"
+ds_delete_tasks(task_ids=[...], force_complete=true)
+```
+
+Confirm with the user first if the list is long or includes anything still seeding.

--- a/skills/synology-nas/references/files.md
+++ b/skills/synology-nas/references/files.md
@@ -1,0 +1,98 @@
+# File Station: files & directories
+
+## Tools
+
+| Tool | Purpose | Required |
+|------|---------|----------|
+| `list_shares` | List top-level shares (Photos, video, homes, …) | — |
+| `list_directory` | List contents of a path | `path` |
+| `get_file_info` | Detailed metadata for one file/dir | `path` |
+| `get_file_content` | Read the bytes of a file | `path` |
+| `search_files` | Pattern search under a path (wildcards: `*.pdf`) | `path`, `pattern` |
+| `create_file` | Create a new file with content | `path` |
+| `create_directory` | Make a new folder | `folder_path`, `name` |
+| `rename_file` | Rename in-place | `path`, `new_name` |
+| `move_file` | Move (or rename across paths) | `source_path`, `destination_path` |
+| `delete` | Delete file or directory (auto-detects type) | `path` |
+
+All accept the optional `nas_name` / `base_url` target.
+
+## Path conventions
+
+- Every path **must start with `/`**. Relative paths are rejected.
+- The root `/` is empty for file operations — it's the share index. Use `list_shares` to enumerate.
+- Real data lives under `/volume1/...` (or `/volume2/...`, etc., on multi-volume systems). The shares like `Photos`, `homes`, `video` are accessible at `/Photos`, `/homes`, `/video` — they're symlinks/mounts for the underlying `/volume1/Photos` etc.
+- When in doubt, `list_directory` the parent before constructing a child path. NAS layouts vary by user.
+
+## Workflow patterns
+
+### Search before you operate
+
+If the user says "delete all the .DS_Store files in Photos", don't try to walk the tree manually. Use `search_files`:
+
+```
+search_files(path="/Photos", pattern=".DS_Store")
+```
+
+Then summarize what you found and confirm before bulk-deleting.
+
+### Create a directory tree
+
+`create_directory` accepts `force_parent: true` to create intermediate parents. Use it when the user gives you a deep path that doesn't exist yet — saves multiple round-trips:
+
+```
+create_directory(folder_path="/volume1/projects", name="2026/q2/budgets", force_parent=true)
+```
+
+### Reading file content
+
+`get_file_content` returns the file bytes. For large files this is wasteful; use `get_file_info` first if the user only wants metadata (size, mtime). Don't dump file content to chat unless the user asked to see it.
+
+### Move vs. rename
+
+- `rename_file` keeps the file in the same directory. Use for "rename foo.txt to bar.txt".
+- `move_file` changes the path. It also handles renaming across directories — so for "move foo.txt to /archive/foo-old.txt", use `move_file`, not `rename_file` followed by `move_file`.
+
+## Gotchas
+
+- **`delete` is recursive on directories.** It auto-detects file vs. directory. Confirm with the user before deleting anything that looks like a folder, especially if it's not empty.
+- **Overwrite is opt-in.** `create_file` and `move_file` default `overwrite: false`. If the user says "replace the existing one", set `overwrite: true` explicitly — don't silently fail and retry.
+- **Trash isn't automatic.** `delete` is permanent unless DSM Recycle Bin is enabled on the share. Mention this if the user is deleting something irreplaceable.
+- **Case sensitivity** depends on the underlying filesystem (Btrfs/ext4 are case-sensitive, eCryptfs may differ). Don't assume.
+- **Path encoding**: paths with spaces, accents, or non-ASCII characters work fine; just pass them as-is in the JSON. Don't URL-encode.
+
+## Examples
+
+### "What's in my Photos folder?"
+
+```
+list_directory(path="/Photos")
+```
+
+### "Find all PDFs in /volume1/documents"
+
+```
+search_files(path="/volume1/documents", pattern="*.pdf")
+```
+
+### "Save these notes to my homes folder"
+
+```
+create_file(
+  path="/homes/<user>/notes/2026-04-29.md",
+  content="...",
+  overwrite=false
+)
+```
+
+If the parent dir doesn't exist, you'll get an error — fall back to `create_directory(force_parent=true)` first, then retry.
+
+### "Move last month's photos into the archive"
+
+```
+search_files(path="/Photos", pattern="*.jpg") # to find them
+# then per-file:
+move_file(source_path="/Photos/2026-03-01.jpg", destination_path="/Photos/archive/2026-03/2026-03-01.jpg", overwrite=false)
+```
+
+For batch moves, surface a summary first and confirm before iterating.

--- a/skills/synology-nas/references/health.md
+++ b/skills/synology-nas/references/health.md
@@ -1,0 +1,110 @@
+# Health monitoring
+
+## Tools
+
+| Tool | What it returns |
+|------|-----------------|
+| `synology_health_summary` | **Aggregate**: system info + utilization + disk health + volume status in one call |
+| `synology_system_info` | Model, serial, DSM version, uptime, system temp |
+| `synology_utilization` | Real-time CPU, memory, swap, disk I/O |
+| `synology_disk_health` | Per-disk: SMART status, model, temp, size |
+| `synology_disk_smart` | Detailed SMART attributes for a specific disk |
+| `synology_volume_status` | Volumes: status, size, usage, filesystem |
+| `synology_storage_pool` | RAID/SHR pools: level, status, member disks |
+| `synology_network` | Interface status, transfer rates |
+| `synology_ups` | UPS battery, power readings |
+| `synology_services` | Installed packages + running status |
+| `synology_system_log` | Recent system log entries |
+
+All accept `nas_name` / `base_url`.
+
+## The aggregate-first rule
+
+If the user asks anything like:
+
+- "How's the NAS doing?"
+- "Is everything healthy?"
+- "Give me a status report"
+- "Check the NAS"
+
+→ call `synology_health_summary` once. It returns system info, utilization, disk health, and volume status in a single payload. Anything finer is a follow-up call only if the summary surfaces something interesting.
+
+Use the individual tools when:
+
+- The user asked a specific question (e.g., "what's the CPU at?" → `synology_utilization`).
+- You're drilling into something the summary flagged (e.g., disk shows warning → `synology_disk_smart` for that disk).
+- The summary tool isn't enough — `storage_pool`, `network`, `ups`, `services`, `system_log` aren't included in the summary.
+
+## Reading the summary
+
+The summary returns four sections. When presenting to a user, scan for these red flags first:
+
+- **System**: temperature unusually high (CPU > 80°C, system > 60°C is worth flagging), uptime extremely short (recent unplanned reboot?).
+- **Utilization**: CPU sustained >80%, memory near 100% with high swap, disk I/O wait time elevated.
+- **Disk health**: any disk with `status` other than `normal`. SMART warnings are pre-failure indicators — flag them clearly.
+- **Volume status**: anything not `normal` (`degraded`, `crashed`, `repairing`). Usage >90% is worth mentioning.
+
+Lead with problems. If everything is green, say so briefly — don't recite every metric.
+
+## Drilling into a problem disk
+
+When `synology_disk_health` shows a disk with warnings:
+
+```
+synology_disk_smart(disk_id="<id from disk_health>")
+```
+
+This returns the full SMART attribute table. Key attributes for layman explanations:
+- `Reallocated_Sector_Ct` — bad sectors remapped. Non-zero is concerning, growing over time is more so.
+- `Current_Pending_Sector` — sectors waiting for reallocation. Non-zero is concerning.
+- `Offline_Uncorrectable` — sectors that failed to read. Non-zero means data loss risk.
+- `Temperature_Celsius` — running hot reduces lifespan.
+
+Don't speculate beyond the data. If a disk is degraded, recommend the user back up critical data and consider a replacement; don't try to "fix" it from inside DSM.
+
+## Storage pools and RAID
+
+`synology_storage_pool` shows the RAID/SHR layer underneath volumes. Useful when:
+
+- A volume is degraded — check the pool to see which disk needs replacing.
+- The user is planning capacity changes — pool-level free space matters.
+- SHR (Synology Hybrid RAID) is in use and the user wants to understand the layout.
+
+## Logs and services
+
+- `synology_system_log` — recent entries. Useful for "what happened last night?" or "why did it reboot?". Don't fetch unless the user is investigating a specific event.
+- `synology_services` — installed packages and running status. Useful when troubleshooting a missing feature ("Is Download Station running? Is Plex installed?").
+
+## Gotchas
+
+- **Don't fan out by default.** Calling 4 individual health tools when `synology_health_summary` would have done is wasteful and slow.
+- **Don't speculate on temperature thresholds.** Drive-specific thresholds vary (a WD Red at 50°C is fine; a Seagate Ironwolf at 60°C might be flagged). Report the number and DSM's own status field; let the user decide whether it's concerning unless the value is clearly extreme.
+- **`synology_system_log` can be large.** Default limits apply, but explicitly summarize for the user — don't dump raw logs to chat.
+- **UPS not present**: `synology_ups` will return an empty/no-device response on NASes without a UPS attached. Don't treat that as an error.
+
+## Examples
+
+### "Health check the NAS"
+
+```
+synology_health_summary
+```
+
+Then summarize: green check on system/CPU/memory/disks/volumes, or call out anything not normal.
+
+### "One disk is yellow — what's wrong?"
+
+```
+synology_disk_health  # find the disk with warning, note its ID
+synology_disk_smart(disk_id="<id>")
+```
+
+Surface Reallocated_Sector_Ct, Current_Pending_Sector, Offline_Uncorrectable, and temp. Recommend backup + replacement if any of those are non-zero and growing.
+
+### "Is the network slow?"
+
+```
+synology_network
+```
+
+Returns per-interface transfer rates. Compare against the link speed (1 Gbps = ~125 MB/s ceiling) before declaring a problem.

--- a/skills/synology-nas/references/shares-nfs.md
+++ b/skills/synology-nas/references/shares-nfs.md
@@ -1,0 +1,105 @@
+# Shares & NFS
+
+## Tools
+
+| Tool | Purpose | Required |
+|------|---------|----------|
+| `synology_create_share` | Create a new shared folder | `share_name` |
+| `synology_nfs_status` | NFS service status & config | — |
+| `synology_nfs_enable` | Enable/disable the NFS service | `enabled` |
+| `synology_nfs_list_shares` | List shares with their NFS export rules | — |
+| `synology_nfs_set_permission` | Set NFS access for a host on a share | `share_name`, `client` rules |
+
+All accept `nas_name` / `base_url`.
+
+## Shares vs. directories — the distinction
+
+A **share** is a top-level mount point (Photos, video, homes, downloads). It's an admin-level construct: it has its own permissions, optional encryption, optional quota, and is what shows up under `/` to clients. Creating one requires admin privileges and uses `synology_create_share`.
+
+A **directory under a share** (e.g., `/Photos/2026/april`) is just a folder. Use `create_directory` from File Station — see [files.md](files.md).
+
+If the user says "create a share" or "add a new share", they want `synology_create_share`. If they say "create a folder", they want `create_directory`. When ambiguous ("create a Photos area"), ask.
+
+## Creating a share
+
+```
+synology_create_share(share_name="projects", description="Engineering projects")
+```
+
+Common optional fields: location (which volume), encryption, quota. Surface DSM's response — it includes the new share's path.
+
+## NFS workflow
+
+Most users won't use NFS unless they're mounting the NAS from Linux, macOS, or another NAS. The flow:
+
+1. **Check status**: `synology_nfs_status` — is the service even on?
+2. **Enable if needed**: `synology_nfs_enable(enabled=true)`. Idempotent — calling on an already-enabled service is harmless.
+3. **List shares**: `synology_nfs_list_shares` — see what's currently exported and to which clients.
+4. **Set permission**: `synology_nfs_set_permission` to add/modify a client rule on a specific share.
+
+### NFS permission shape
+
+A permission rule binds a share to a client (host or subnet) with a privilege set:
+
+- **Privilege**: `rw` (read-write), `ro` (read-only), or `no_access`.
+- **Squash**: `no_mapping`, `root_squash` (default — root mapped to nobody), `all_squash` (everyone mapped to nobody), `map_user_to_admin`. Default is `root_squash` — only override if the user has a specific reason (e.g., admin-mapped backups).
+- **Security**: `sys` (default), `krb5`, `krb5i`, `krb5p` if Kerberos is configured. Stick with `sys` unless the user mentions Kerberos.
+- **Async / sync**: async is faster, sync is safer for transactional writes.
+
+When in doubt, mirror what's already exported on a similar share — `synology_nfs_list_shares` shows existing rules.
+
+## DSM 7.3.2 note
+
+Earlier MCP versions had bugs creating shares on DSM 7.3.2 (additional-param encoding, missing `SynoToken` headers). These are fixed in current builds. If the user reports share creation failing on DSM 7.3.2, first check that they're on the latest MCP version — don't reinvent the workaround. Issue history: project commits `f62088d`, `5886007`, `9729915`.
+
+## Gotchas
+
+- **NFS service is off by default** on fresh DSM installs. If `synology_nfs_set_permission` fails, check `synology_nfs_status` first.
+- **Firewall**: even with NFS enabled and permissions set, the DSM firewall may block port 2049. The MCP can't toggle the firewall — direct the user to DSM's Control Panel → Security → Firewall if mounts time out.
+- **Permission changes are immediate** — no need to restart the service.
+- **Share names are case-sensitive on the wire** but DSM presents them case-insensitively in the UI. Use the exact name returned by `synology_nfs_list_shares` to avoid mismatches.
+- **Don't set `all_squash` casually** — it's useful for guest-style public shares but breaks per-user ownership. The default `root_squash` is what most users want.
+
+## Examples
+
+### "Mount the photos share on my Linux box at 192.168.1.50, read-only"
+
+```
+synology_nfs_status                                  # confirm enabled
+synology_nfs_set_permission(
+  share_name="Photos",
+  client="192.168.1.50",
+  privilege="ro",
+  squash="root_squash",
+  security="sys",
+)
+```
+
+Then tell the user the mount command they'd run on the client:
+
+```
+sudo mount -t nfs <nas-ip>:/volume1/Photos /mnt/photos -o ro,nfsvers=4
+```
+
+### "Open NFS access to the whole subnet"
+
+Use a CIDR client string:
+
+```
+synology_nfs_set_permission(
+  share_name="backups",
+  client="192.168.1.0/24",
+  privilege="rw",
+  squash="root_squash",
+)
+```
+
+Confirm with the user before opening RW to a whole subnet — it's a meaningful trust decision.
+
+### "Create a new share for project files"
+
+```
+synology_create_share(share_name="projects-2026", description="2026 project work")
+```
+
+If the user wants NFS on it too, follow up with `synology_nfs_set_permission`.

--- a/skills/synology-nas/references/users.md
+++ b/skills/synology-nas/references/users.md
@@ -1,0 +1,106 @@
+# User & group management
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| `synology_list_users` | List all DSM users |
+| `synology_get_user` | Get one user's details |
+| `synology_create_user` | Create a new user |
+| `synology_set_user` | Update an existing user |
+| `synology_delete_user` | Delete a user |
+| `synology_list_groups` | List all groups |
+| `synology_list_group_members` | Members of a specific group |
+| `synology_add_user_to_group` | Add a user to a group |
+| `synology_remove_user_from_group` | Remove a user from a group |
+| `synology_get_user_permissions` | Get a user's share-level permissions |
+| `synology_set_user_permissions` | Set a user's share-level permissions |
+
+All accept `nas_name` / `base_url`.
+
+## When to use this domain
+
+User management is **admin-level**. The MCP must be authenticated as a user with admin rights for these calls to succeed. If the user is connecting with a non-admin account (recommended for safety), most of these tools will fail with permission errors — surface that clearly rather than retrying.
+
+The README warns against running the MCP as a primary admin account. If user-management actions are needed, the user should temporarily authenticate with an admin account, do the work, and switch back. Don't try to elevate from inside Claude.
+
+## Read before write
+
+- Before `synology_set_user`: call `synology_get_user` to see the current settings, so updates merge cleanly instead of overwriting fields unintentionally.
+- Before `synology_add_user_to_group` / `synology_remove_user_from_group`: `synology_list_group_members` to confirm the current state.
+- Before `synology_set_user_permissions`: `synology_get_user_permissions` to see what's already granted.
+
+DSM's user model is additive (group membership grants permissions, plus per-user overrides). Reading first prevents accidental privilege escalation/demotion.
+
+## Workflow patterns
+
+### Creating a new user
+
+`synology_create_user` requires at minimum a name and password. Common optional fields:
+
+- `email` — for password recovery and notifications.
+- `description` — surface this when listing users.
+- `groups` — initial group memberships. Common groups: `users`, `administrators`, `http`.
+- `expired` — account expiry date.
+- `password_never_expire` — boolean.
+
+For most setups: create with `groups: ["users"]` and add to additional groups via `synology_add_user_to_group` afterward. Putting someone in `administrators` is a meaningful trust decision — confirm before doing it.
+
+### Setting share permissions
+
+`synology_set_user_permissions` controls per-share access (read, write, none). Permission entries look like:
+
+```json
+{
+  "share_name": "Photos",
+  "permission": "rw"  // or "ro", "no_access"
+}
+```
+
+Pass an array of entries; not-mentioned shares retain their existing permission. To revoke access, set `"permission": "no_access"` explicitly — don't just omit the share.
+
+### Deleting users
+
+`synology_delete_user` is permanent. The user's home directory may or may not be removed depending on DSM's "preserve home" setting. Ask the user whether they want home-folder cleanup as a separate step (using `delete` against `/homes/<user>`).
+
+## Gotchas
+
+- **Built-in users**: `admin`, `guest`, and any DSM-built-in accounts behave specially. Don't try to delete `admin` (DSM may refuse). Don't change `guest`'s group memberships unless the user knows what they're doing.
+- **Password requirements**: DSM enforces minimum length and complexity. If `synology_create_user` fails with a password error, surface DSM's specific requirements rather than retrying with a slightly different password.
+- **Group changes don't always take effect immediately for active sessions** — a user logged in when added to a group may need to log out and back in to see new permissions on shares.
+- **Deleting a user doesn't revoke active sessions automatically.** If you're removing access urgently, also tell the user to invalidate sessions in DSM Control Panel → Security → Account → Online Users.
+- **Quota** is a separate feature managed via shared-folder quota or volume quota — not directly exposed in user-management tools here.
+
+## Examples
+
+### "Create a user 'photographer' with read-only access to Photos"
+
+```
+synology_create_user(
+  username="photographer",
+  password="<strong-pass>",
+  description="Read-only photo access",
+  groups=["users"],
+)
+synology_set_user_permissions(
+  username="photographer",
+  permissions=[{"share_name": "Photos", "permission": "ro"}]
+)
+```
+
+### "Who's in the administrators group?"
+
+```
+synology_list_group_members(group_name="administrators")
+```
+
+### "Remove user 'temp-contractor'"
+
+```
+synology_get_user(username="temp-contractor")        # confirm it's the right one
+synology_delete_user(username="temp-contractor")     # permanent
+# optionally:
+delete(path="/homes/temp-contractor")                # cleanup home dir
+```
+
+Confirm both steps with the user before running.


### PR DESCRIPTION
## Summary

Adds an Anthropic Agent Skill at `skills/synology-nas/` that teaches Claude how to use the `mcp-server-synology` MCP tools effectively. The skill is purely additive — works in Claude Code, Claude Desktop, and claude.ai alongside the MCP, only triggers on Synology/NAS-related prompts.

Closes #5.

## What's in it

- **`SKILL.md`** — high-level workflow patterns + domain map (~110 lines)
- **`references/`** — six progressive-disclosure subdocs, one per domain:
  - `auth.md` — multi-NAS targeting, settings.json, session model
  - `files.md` — File Station ops, path conventions
  - `downloads.md` — Download Station task lifecycle
  - `health.md` — aggregate-first rule, SMART drilldowns
  - `shares-nfs.md` — share creation, NFS permissions
  - `users.md` — user/group/permission management
- **`evals/evals.json`** — three planning-eval prompts with assertions

## What it encodes (that per-tool descriptions can't)

- Prefer `synology_health_summary` over fanning out to `synology_system_info` + `synology_utilization` + `synology_disk_health` + `synology_volume_status` for "how's the NAS doing?"-style requests
- Use `synology_list_nas` first to disambiguate multi-NAS setups; require `nas_name` on every operational call when more than one NAS is configured
- Trust auto-login; don't call `synology_login` reflexively
- Path conventions: paths must start with `/`, real data lives under `/volume1/`
- Read-before-mutate for destructive ops (`ds_delete_tasks`, `delete`, `synology_delete_user`)
- Distinguish *creating a share* (`synology_create_share`) from *creating a folder under a share* (`create_directory`)

## Validation

### Planning eval (synthetic)

| | With skill | Without skill | Δ |
|---|---|---|---|
| Pass rate | 100% (17/17) | 69% (12/17) | +31pp |

Three test prompts (in `evals/evals.json`) targeting aggregate-vs-fanout, discovery + path conventions, and read-before-mutate safety. Baseline confidently invented tool names that don't exist (`synology_list_disks`, `synology_list_volumes`) and set `force_complete=false` based on a fabricated reading of the flag — exactly the kind of confident-wrong behavior the skill prevents.

### Real-world eval (live MCP, real NAS)

Ran the test plan below against the running MCP container connected to a real Synology (DSM 7.x):

| # | Prompt | Skill triggered | Tools called | Verdict |
|---|---|---|---|---|
| 1 | "quick health check on my synology" | ✅ | `list_nas` → `health_summary` → fallback to individual tools when summary returned empty | ✅ **PASS** — followed aggregate-first rule, recovered correctly |
| 2 | "find any .raw files in the photos folder on my NAS, /volume1/Photos somewhere" | ✅ | `list_nas` → `search_files(/volume1/Photos, *.raw)` → `list_shares` (recovery) | ✅ **PASS** — absolute path, recovered cleanly when path didn't exist |
| 3 | "list every download task that's been seeding for a while" | ❌ | `list_nas` → `ds_list_tasks` | ⚠️ **PARTIAL** — skill didn't fire, but Claude did the right thing anyway |

**Triggering caveat:** the skill description doesn't reliably fire on every Synology-relevant prompt (test 3). When it does fire (tests 1 & 2), tool selection is correct.

## Other changes

- `README.md` — new **🧠 Claude Code / Claude.ai Skill** section with install instructions
- `CHANGELOG.md` — `[Unreleased]` entry
- `.gitignore` — excludes `skills/*-workspace/` so future eval artifacts don't get accidentally staged

## MCP-side findings (out of scope for this PR, worth filing separately)

Surfaced while running the real-world tests:

1. **Stale docker image**: `docker compose up -d` alone exposed only 17/47 tools — the baked image predates the health/NFS/users modules. `docker compose up -d --build` fixes it. Worth a README note or CI-rebuilt image.
2. **DSM permissions**: a non-admin account (per the README's security recommendation) hits DSM error 104/105 ("insufficient privileges") on health endpoints. The skill works correctly — it tries the aggregate, sees it's empty, falls back — but the data isn't accessible. Worth a note in `references/health.md` or the README.

## Test plan

- [x] Install via `~/.claude/skills/synology-nas/` (symlink) on a machine with `mcp-server-synology` configured
- [x] Ask Claude "how's my NAS doing?" — expect `synology_health_summary` (one call), not fan out → ✅ aggregate called first; fallback to individuals only after empty response
- [x] Ask "find any .raw files in the photos folder" — expect `synology_list_nas` followed by `search_files` with absolute path → ✅
- [x] Ask to list/clean up download tasks — expect `ds_list_tasks` first → ✅ (skill didn't trigger, but tool selection was correct)