### PR TITLE
ci: add Claude Code @claude-mention reviewer workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,36 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

Wires up `anthropics/claude-code-action@v1` so commenting `@claude` on a PR or issue invokes Claude Code in CI. Mention-only trigger (no auto-run on every PR open) for cost control.

Auth uses `CLAUDE_CODE_OAUTH_TOKEN` (from a Claude Pro/Max subscription via `claude setup-token`) instead of `ANTHROPIC_API_KEY`, so usage counts against the existing subscription rather than per-token API billing.

## Setup needed before merging (or right after)

- [ ] Install the [Claude GitHub App](https://github.com/apps/claude) on this repo
- [ ] Add `CLAUDE_CODE_OAUTH_TOKEN` to repo secrets — `Settings → Secrets and variables → Actions`

Without those two, the workflow is harmless but inert: the `@claude` mention won't fire anything until the App is installed.

## Test plan

- [ ] Merge, then comment `@claude review this PR` on a follow-up PR
- [ ] Watch the Actions tab — the `Claude Code` workflow should pick it up and Claude posts a reply