### PR TITLE
ci: check out PR head SHA on issue_comment triggers

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,9 +25,19 @@ jobs:
       id-token: write
       actions: read
     steps:
+      - name: Resolve PR head SHA on issue_comment
+        id: pr-ref
+        if: github.event_name == 'issue_comment' && github.event.issue.pull_request != null
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SHA=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.issue.number }}" --jq .head.sha)
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          ref: ${{ steps.pr-ref.outputs.sha || github.ref }}
           fetch-depth: 1
 
       - name: Run Claude Code


### PR DESCRIPTION
## Summary

Follow-up to #15. Codex flagged a P1 in the equivalent PR on a sibling repo: `actions/checkout` without an explicit `ref` defaults to `GITHUB_REF`, which on `issue_comment` events points to the repo's default branch — not the PR head. So commenting `@claude` on a PR conversation tab would run Claude against `main`'s code instead of the PR's.

(Inline review comments triggered via `pull_request_review_comment` already get the right ref, so those weren't affected.)

## Fix

Add a step that resolves the PR head SHA via the GitHub API when the trigger is `issue_comment` on a PR, then pass it to `actions/checkout`. SHA (not ref name) to avoid races if the head moves between trigger and checkout.

```yaml
- name: Resolve PR head SHA on issue_comment
  id: pr-ref
  if: github.event_name == 'issue_comment' && github.event.issue.pull_request != null
  env:
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  run: |
    SHA=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.issue.number }}" --jq .head.sha)
    echo "sha=$SHA" >> "$GITHUB_OUTPUT"

- name: Checkout repository
  uses: actions/checkout@v6
  with:
    ref: ${{ steps.pr-ref.outputs.sha || github.ref }}
    fetch-depth: 1
```

## Test plan

- [ ] Merge, comment `@claude what's at line 1 of README.md` on a follow-up PR
- [ ] Confirm in workflow logs that the checkout used the PR head SHA, and Claude saw PR-specific content