### PR TITLE
fix: system_info fails with error 104 on DSM 7.x (SYNO.DSM.Info minVersion=2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- `system_info`: use `SYNO.DSM.Info` version 2 as fallback on DSM 7.x — version 1 is below `minVersion` and returns error 104; `SYNO.DSM.Info/getinfo/v2` returns model, serial, DSM version string, RAM, temperature, and uptime successfully.
+
 ### Added
 - `synology-nas` Anthropic Agent Skill at `skills/synology-nas/` — teaches Claude how to use the MCP tools effectively (multi-NAS targeting, aggregate health checks, path conventions, per-domain workflows for files/downloads/health/NFS/users). Works in Claude Code, Claude Desktop, and claude.ai. Closes #5.
 

--- a/src/health/synology_health.py
+++ b/src/health/synology_health.py
@@ -49,12 +49,11 @@ class SynologyHealth:
 
     def system_info(self) -> Dict[str, Any]:
         """Get system model, serial, DSM version, uptime, temperature."""
-        return self._api_call_with_fallback(
-            "SYNO.Core.System",
-            "info",
-            "SYNO.DSM.Info",
-            "getinfo",
-        )
+        result = self._api_call("SYNO.Core.System", "info")
+        if result.get("success"):
+            return result
+        # SYNO.DSM.Info requires version 2 on DSM 7.x (minVersion=2, maxVersion=2)
+        return self._api_call("SYNO.DSM.Info", "getinfo", 2)
 
     def utilization(self) -> Dict[str, Any]:
         """Get real-time CPU, memory, swap, and disk I/O utilization."""

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,6 +1,7 @@
 """Health monitoring module tests."""
 
 import pytest
+from unittest.mock import patch
 
 
 @pytest.mark.real_nas
@@ -196,6 +197,46 @@ class TestSynologyHealth:
             print(f"   Sections: {list(data.keys())}")
         else:
             print(f"⚠️  Health summary failed: {result.get('error')}")
+
+
+class TestSystemInfoFallback:
+    """Unit tests for system_info DSM 6/7 fallback behaviour (no live NAS required)."""
+
+    def _make_health(self):
+        from health.synology_health import SynologyHealth
+        return SynologyHealth("http://nas:5000", "fake-sid", verify_ssl=False)
+
+    def test_primary_success(self):
+        """Uses SYNO.Core.System when it returns data."""
+        health = self._make_health()
+        expected = {"success": True, "data": {"model": "DS920+"}}
+        with patch.object(health._api, "get", return_value=expected) as mock_get:
+            result = health.system_info()
+        assert result == expected
+        mock_get.assert_called_once_with("SYNO.Core.System", "info", 1, None)
+
+    def test_fallback_uses_version_2(self):
+        """Falls back to SYNO.DSM.Info v2 when SYNO.Core.System fails."""
+        health = self._make_health()
+        dsm_info = {"success": True, "data": {"model": "DS1621+", "version_string": "DSM 7.3.2-86009"}}
+
+        def side_effect(api, method, version=1, extra_params=None):
+            if api == "SYNO.Core.System":
+                return {"success": False, "error": {"code": 1006}}
+            if api == "SYNO.DSM.Info" and version == 2:
+                return dsm_info
+            return {"success": False, "error": {"code": 999}}
+
+        with patch.object(health._api, "get", side_effect=side_effect):
+            result = health.system_info()
+        assert result == dsm_info
+
+    def test_both_fail(self):
+        """Returns the fallback error when both APIs fail."""
+        health = self._make_health()
+        with patch.object(health._api, "get", return_value={"success": False, "error": {"code": 104}}):
+            result = health.system_info()
+        assert not result.get("success")
 
 
 def test_health_url_construction():


### PR DESCRIPTION
## Problem

`synology_system_info` returns `{"error": {"code": 104}, "success": false}` on DSM 7.x.

Root cause: `_api_call_with_fallback` passes `version=1` to both the primary
(`SYNO.Core.System`) and the fallback (`SYNO.DSM.Info`). On DSM 7.x, the API
registry reports `SYNO.DSM.Info` as `minVersion=2` — calling it with version 1
returns error 104 ("requested version does not support the functionality").

`SYNO.Core.System/info` also fails with error 1006 on DS1621+ (DSM 7.3.2-86009 Update 3),
making the fallback path the only working route — and it must use version 2.

## Verified on

- NAS model: DS1621+
- DSM version: 7.3.2-86009 Update 3
- API registry: `SYNO.DSM.Info` → `minVersion=2, maxVersion=2`
- `SYNO.DSM.Info/getinfo/v2` returns: model, serial, version_string, RAM, temperature, uptime ✅

## Fix

Split `system_info` to call the fallback explicitly with `version=2` instead of
sharing `version=1` via `_api_call_with_fallback`. No changes to the shared
helper or other callers.

## Tests added

New `TestSystemInfoFallback` class with three mock-based unit tests (no live NAS required):
- `test_primary_success` — SYNO.Core.System success path unchanged
- `test_fallback_uses_version_2` — confirms fallback calls SYNO.DSM.Info with version=2
- `test_both_fail` — error passthrough when both APIs fail

All pass: `pytest tests/test_health.py -v -k "not real_nas"` → 5 passed