### PR TITLE
ci: skip Claude workflow on bot-triggered events

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,15 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.actor != 'copilot-pull-request-reviewer[bot]' &&
+      github.actor != 'copilot-pull-request-reviewer' &&
+      github.event.sender.type != 'Bot' &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Adds an actor/sender guard to the Claude Code workflow `if:` so events triggered by bots (e.g. `copilot-pull-request-reviewer`) no longer queue a workflow run.
- Previously, requesting a Copilot review on a PR fired `pull_request_review: submitted`, which queued a Claude run that immediately skipped on the `@claude` content check — but still showed up as "Action required" for first-time contributors.

## Test plan
- [ ] Open a PR and request a Copilot review → confirm no new `Claude Code` workflow run is queued.
- [ ] Comment `@claude review` on a PR → confirm Claude Code workflow still runs as expected.