### PR TITLE
ci: refresh Dependabot config (PR limits + labels)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## Summary
- Adds `open-pull-requests-limit: 5` and `labels` to both ecosystems in `.github/dependabot.yml`.
- Modifying the config also forces Dependabot to re-evaluate, clearing the stale `Dependabot couldn't find a <anything>.yml` warning shown on the Dependabot page.

## Context
The warning persisted because `dependabot.yml` was added (in `739ae19`) before any workflow file existed at `.github/workflows/`. Once `claude.yml` was added later, Dependabot didn't automatically re-check the github-actions ecosystem, so the original error message stuck around.

## Test plan
- [ ] Merge and confirm the Dependabot page no longer shows the warning for the `github-actions` ecosystem.
- [ ] Confirm new Dependabot PRs (when they appear) carry the new labels.