### PR TITLE
ci(review): allow dependabot to trigger Claude PR review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "dependabot"
           prompt: |
             REPO: ${{ github.repository }}
             PR: #${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
- `anthropics/claude-code-action@v1` blocks bot-initiated runs by default, so every Dependabot PR fails the `PR Review` workflow (see #23 — `Workflow initiated by non-human actor: dependabot (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.`).
- Add `allowed_bots: "dependabot"` to `.github/workflows/claude-review.yml` so dependency PRs get reviewed. Scoped to dependabot rather than `"*"` to avoid attracting unrelated bot traffic.

## Test plan
- [ ] Merge, then verify the next Dependabot PR's `PR Review` check passes
- [ ] Confirm human-opened PRs still trigger the review action normally