### PR TITLE
Add optional HTTP/SSE transport via mcp-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,82 @@ If you prefer not to use Docker:
   }
 }
 ```
+## 🌐 Remote HTTP/SSE Deployment (NEW)
+
+By default the server speaks **stdio**, which means the MCP client has to spawn the process locally (or via a bridge such as SSH/docker exec). For setups where the NAS is remote (different machine from where Claude/Cursor runs), you can expose the MCP server over **HTTP/SSE** using [`mcp-proxy`](https://github.com/sparfenyuk/mcp-proxy). This makes it consumable by any MCP client that supports URL-based connectors — exactly like `ha-mcp` or other "remote" MCP servers.
+
+### Architecture
+
+```
+[Claude Desktop / Cursor / ...]
+        │
+        │ HTTPS (URL connector)
+        ▼
+[Reverse proxy: DSM / Nginx / Traefik / Caddy]
+        │  (TLS termination + auth)
+        │ HTTP localhost:8765
+        ▼
+[Docker container]
+  └─ mcp-proxy
+       └─ python main.py (stdio)
+```
+
+### Deploy
+
+1. Make sure `mcp-proxy` is in `requirements.txt` (it is, as of this version).
+2. Use the provided `docker-compose.http.yml`:
+
+```bash
+# Edit credentials in docker-compose.http.yml first
+docker compose -f docker-compose.http.yml up -d --build
+docker logs -f synology-mcp-http
+```
+
+You should see mcp-proxy report `Uvicorn running on http://0.0.0.0:8765` and the auto-login succeed.
+
+### Reverse proxy
+
+Most MCP clients require HTTPS, so the HTTP endpoint must be fronted by a TLS-terminating reverse proxy. For DSM users, the built-in **Login Portal → Reverse Proxy** does the job:
+
+- **Source**: `HTTPS`, hostname `synology-mcp.example.com`, port `443`
+- **Destination**: `HTTP`, `localhost`, port `8765`
+- **Custom Headers**: click *Create → WebSocket* (adds the headers needed for SSE/long-lived connections)
+
+For Nginx, the equivalent is:
+
+```nginx
+location / {
+    proxy_pass http://localhost:8765;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    # SSE-specific
+    proxy_buffering off;
+    proxy_cache off;
+    proxy_read_timeout 24h;
+}
+```
+
+### Client configuration
+
+In Claude Desktop (or any MCP client that supports remote connectors), add a custom connector pointing at:
+
+```
+https://synology-mcp.example.com/sse
+```
+
+No `command`, no `args`, no local Python — just a URL.
+
+### Security
+
+`mcp-proxy` does **not** provide server-side authentication. Anything that can reach the HTTP endpoint can call every tool. Mitigations:
+
+- Keep it on a private network or behind a VPN
+- Use the reverse proxy to enforce an IP allow-list
+- Add Basic Auth / mTLS / OAuth2 proxy at the reverse proxy layer
+- Use a dedicated low-privilege DSM user (already recommended in the security warning above)
 
 ## 🌟 Xiaozhi Integration
 

--- a/docker-compose.http.yml
+++ b/docker-compose.http.yml
@@ -1,0 +1,68 @@
+# Alternative deployment for HTTP/SSE transport
+#
+# This compose file exposes the Synology MCP server over HTTP/SSE using
+# mcp-proxy (https://github.com/sparfenyuk/mcp-proxy) so it can be consumed
+# as a *remote* MCP server by clients that support URL-based connectors
+# (Claude Desktop "Custom connectors", Claude.ai web, Cursor, etc.).
+#
+# The stdio mode in the main docker-compose.yml stays unchanged; use this
+# file when you want a long-running, network-accessible MCP server.
+#
+# Prerequisites:
+#   - mcp-proxy added to requirements.txt (already done in this PR)
+#   - A reverse proxy in front (DSM, Nginx, Traefik, Caddy...) terminating
+#     TLS, since most MCP clients only accept HTTPS endpoints.
+#
+# Usage:
+#   1. Copy this file to docker-compose.http.yml (or use -f docker-compose.http.yml)
+#   2. Edit the environment block with your credentials (or use settings.json)
+#   3. docker compose -f docker-compose.http.yml up -d --build
+#   4. Point your reverse proxy at http://<host>:8765
+#   5. In your MCP client, add a custom connector:
+#        URL: https://your-domain.example.com/sse
+#
+# Security note:
+#   mcp-proxy does NOT provide server-side authentication. Put it behind a
+#   reverse proxy that adds authentication (Basic Auth, mTLS, OAuth2 proxy,
+#   IP allow-list) before exposing it to anything other than a trusted LAN
+#   or VPN.
+
+services:
+  synology-mcp-http:
+    build: .
+    container_name: synology-mcp-http
+    # mcp-proxy spawns `python main.py` as a stdio child and exposes it
+    # over SSE/Streamable HTTP on port 8765.
+    command:
+      - "mcp-proxy"
+      - "--host=0.0.0.0"
+      - "--port=8765"
+      - "--pass-environment"
+      - "--allow-origin=*"
+      - "--"
+      - "python"
+      - "main.py"
+    ports:
+      - "8765:8765"
+    environment:
+      - XDG_CONFIG_HOME=/home/mcpuser/.config
+      # Required: Synology NAS connection
+      - SYNOLOGY_URL=https://your-nas.example.com:5001
+      - SYNOLOGY_USERNAME=your_username
+      - SYNOLOGY_PASSWORD=your_password
+      # Optional
+      - AUTO_LOGIN=true
+      - VERIFY_SSL=false
+      - DEBUG=false
+      - LOG_LEVEL=INFO
+      - ENABLE_XIAOZHI=false
+    volumes:
+      - ./logs:/app/logs
+      # Multi-NAS settings.json support (XDG path) — optional
+      - ${XDG_CONFIG_HOME:-$HOME/.config}/synology-mcp:/home/mcpuser/.config/synology-mcp:ro
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ requests
 mcp>=1.27.1
 python-dotenv
 websockets>=16.0
+mcp-proxy>=0.7.0
 
 # Testing dependencies
 pytest>=9.0.3


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>Add optional HTTP/SSE transport via mcp-proxy</h1>
<h2>What this PR adds</h2>
<p>A second deployment mode that exposes the Synology MCP server over <strong>HTTP/SSE</strong> so it can be consumed as a <em>remote</em> MCP server by clients that only accept URL-based connectors (Claude Desktop "Custom connectors", Claude.ai, Cursor remote MCP, etc.) — the same UX as <code>ha-mcp</code> and other HTTP-native MCP servers.</p>
<p>This is <strong>purely additive</strong>: the existing stdio mode and the Xiaozhi WebSocket bridge are untouched.</p>
<h2>Why</h2>
<p>Today the only way to use this server from a Claude Desktop that runs on a different machine than the NAS is to bridge stdio over SSH (or run docker-compose from the client machine). That works but it requires SSH keys, sudo for Docker socket access, and a bit of Windows/macOS plumbing. It also doesn't survive a machine change.</p>
<p>An HTTPS endpoint behind a reverse proxy fixes all of that and matches the deployment pattern users already expect (Home Assistant MCP, GitHub MCP, etc.).</p>
<h2>Changes</h2>

File | Change
-- | --
requirements.txt | Add mcp-proxy>=0.7.0
docker-compose.http.yml | New. Reference compose for HTTP deployment, with comments.
README.md | New section "🌐 Remote HTTP/SSE Deployment" with architecture diagram, deploy instructions, reverse-proxy config snippet (DSM + Nginx), and security guidance.


<p>No Python code is changed. The HTTP wrapper is provided entirely by <code>mcp-proxy</code>, which spawns <code>python main.py</code> as a stdio child and exposes the pipe over SSE on a configurable port.</p>
<h2>How it works</h2>
<pre><code>[MCP client] ── HTTPS ──► [reverse proxy] ── HTTP :8765 ──► [mcp-proxy] ── stdio ──► [python main.py]
</code></pre>
<p>The container's <code>command</code> becomes:</p>
<pre><code>mcp-proxy --host=0.0.0.0 --port=8765 --pass-environment --allow-origin='*' -- python main.py
</code></pre>
<h2>Tested with</h2>
<ul>
<li>Synology DSM 7.2 (Container Manager + built-in reverse proxy)</li>
<li>Claude Desktop with a custom connector pointing at <code>https://&lt;subdomain&gt;/sse</code></li>
<li>44 tools enumerated and callable (<code>list_shares</code>, <code>synology_health_summary</code>, <code>synology_disk_health</code>, <code>ds_list_tasks</code>, etc.)</li>
<li>TLS terminated by DSM reverse proxy with a Let's Encrypt cert; IP allow-list on the reverse-proxy profile</li>
</ul>
<h2>Security</h2>
<p>The added section in the README is explicit about it: <code>mcp-proxy</code> has no built-in auth, so the deployment instructions push the user toward a reverse proxy with IP allow-list / Basic Auth / mTLS — and reiterate the existing recommendation to use a dedicated low-privilege DSM user.</p>
<h2>Out of scope (future work)</h2>
<ul>
<li>Native HTTP transport directly inside <code>main.py</code> (would remove the <code>mcp-proxy</code> dependency entirely). FastMCP supports it but that's a bigger refactor.</li>
<li>Multi-NAS routing via mcp-proxy named servers.</li>
<li>OAuth2 / Bearer token enforcement in the proxy layer.</li>
</ul>
<p>Happy to iterate on any of this.</p></body></html><!--EndFragment-->
</body>
</html>