### PR TITLE
ci(review): skip Claude PR review on Dependabot PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -12,6 +12,9 @@ permissions:
 
 jobs:
   review:
+    # Skip on Dependabot PRs: they run with the isolated Dependabot secret store,
+    # so secrets.CLAUDE_CODE_OAUTH_TOKEN is empty and the action always fails.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Problem

Every Dependabot PR (e.g. #26, #28) fails its `review` check:

```
##[error]Environment variable validation failed:
  - Either ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, ... is required
"claude_code_oauth_token": ""   ← empty
```

Dependabot-triggered workflow runs use GitHub's **isolated Dependabot secret store**, which does not contain `CLAUDE_CODE_OAUTH_TOKEN` (it lives in the Actions secret store). So the token resolves to empty, the `claude-code-action` env validation fails, and the check goes red on every dependency bump. `allowed_bots: dependabot` (added in #24) lets Claude *trigger* on these PRs but never gave it credentials in that context.

## Fix

Guard the `review` job to skip Dependabot-authored PRs:

```yaml
if: github.event.pull_request.user.login != 'dependabot[bot]'
```

No more spurious red checks on dependency bumps. Claude review still runs on all human-authored PRs. Chosen over adding the token to the Dependabot secret store to avoid exposing the credential to Dependabot-context runs.

> Note: this PR edits `claude-review.yml`, so its own `review` check may fail with a `401 Workflow validation failed` — that's by design (the token broker validates the workflow against `main`) and is safe to merge through.