### PR TITLE
ci(review): run PR review on fork PRs via pull_request_target

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,7 +1,20 @@
 name: PR Review
 
+# Triggered by `pull_request_target` (not `pull_request`) so the review job runs
+# in the BASE repo's context. This is required for PRs from forks: `pull_request`
+# fork runs get a read-only token with no secrets and no OIDC, so
+# secrets.CLAUDE_CODE_OAUTH_TOKEN / id-token are unavailable and the action fails.
+# `pull_request_target` runs the workflow definition from the base branch with
+# secrets available, regardless of where the PR came from.
+#
+# Security: because this job has secrets, it must NOT execute untrusted PR code.
+# It only checks out the PR head to let Claude READ the diff, and Claude's tools
+# are locked down (gh pr comment/diff/view + inline comments only) — no build,
+# test, or arbitrary command execution. Keep the "require approval for fork PRs"
+# setting on as the anti-abuse gate. Residual risk is prompt injection via PR
+# content, contained by the restricted toolset.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 permissions:
@@ -19,6 +32,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          # Explicitly check out the PR head. With pull_request_target the default
+          # ref is the base branch, but we want Claude to review the PR's code.
+          # We only READ this code (never build/run it) — see the security note above.
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
       - uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
## Problem

The **PR Review** workflow (`claude-review.yml`) triggered on `on: pull_request`. For PRs opened from **forks**, GitHub runs `pull_request` jobs with a **read-only `GITHUB_TOKEN`, no secrets, and no OIDC token** — and approving the run (the first-time-contributor gate) does **not** change that; it only authorizes execution as an anti-abuse measure.

As a result, `anthropics/claude-code-action@v1` died at startup on every fork PR:

```
Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
Could not fetch an OIDC token. Did you remember to add `id-token: write`...
```

So automated review was unavailable for exactly the third-party contributions that benefit from it most (e.g. #25, #27).

## Fix

Switch the trigger to **`pull_request_target`**, which runs the workflow definition from the **base branch in the base repo's context**, where secrets and OIDC are available regardless of where the PR originated. The checkout step now explicitly pins `ref: github.event.pull_request.head.sha` so Claude still reviews the **contributor's** code rather than the base branch.

## Security considerations

`pull_request_target` carries secrets while inspecting untrusted PR content, so this job is deliberately constrained:

- It **only reads** the PR diff and posts comments — it never builds, tests, or runs PR code.
- Claude's toolset stays locked to `gh pr comment/diff/view` + inline comments (no arbitrary command execution).
- The checkout uses `head.sha` (a commit SHA), not `head.ref`/`head.label`, avoiding ref-injection.
- No untrusted free-text is interpolated into any `run:` shell step.
- Keep the **"Require approval for fork PRs"** setting on as the anti-abuse gate.
- Residual risk is prompt injection via PR content, contained by the restricted toolset.

## Note on rollout

`pull_request_target` always uses the workflow from the **base branch**, so this only takes effect once merged to `main`, and only for PRs **opened** afterward (`types: [opened]`). To get a review on the already-open #25 / #27, comment `@claude` on them (the `claude.yml` comment workflow already runs in base context), or close/reopen after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)