### PR TITLE
ci: lock down fork-PR token spend (gate @claude + label-gate PR review)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -17,15 +17,16 @@ name: PR Review
 # content, contained by the restricted, read-only toolset.
 on:
   pull_request_target:
-    # opened: one-time auto-review on a new PR.
-    # reopened: the re-trigger lever — a maintainer re-runs the review by
-    #   closing+reopening the PR (a privileged target workflow can't be re-run
-    #   any other way on an already-open PR).
+    # labeled: the opt-in trigger — review runs only after a maintainer applies
+    #   the 'ai-review' label (see the job's `if:`). This is the token-spend gate.
+    # opened/reopened: re-fire the trigger so a PR that ALREADY carries the label
+    #   (e.g. reopened, or opened by a maintainer who pre-labels) gets reviewed.
+    #   On a fresh unlabeled fork PR these fire but the job is skipped — 0 tokens.
     # NOT synchronize: re-review on every push would double up with the explicit
     #   @claude pings that the auto-pr / auto-issue loops already post per push,
     #   producing two Claude reviews per commit. Re-reviews are driven explicitly
-    #   (auto-pr's ping, a manual @claude, or close+reopen) instead.
-    types: [opened, reopened]
+    #   (re-apply the label, auto-pr's ping, a manual @claude, or close+reopen).
+    types: [opened, reopened, labeled]
 
 permissions:
   contents: read
@@ -35,9 +36,17 @@ permissions:
 
 jobs:
   review:
-    # Skip on Dependabot PRs: they run with the isolated Dependabot secret store,
-    # so secrets.CLAUDE_CODE_OAUTH_TOKEN is empty and the action always fails.
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    # Token-spend gate. This is a privileged pull_request_target run: it carries
+    # secrets and is NOT covered by the fork-PR "require approval" prompt (that
+    # gate is for the `pull_request` event), so without this `if:` it would auto-
+    # run — and spend Claude tokens — on any fork PR from anyone. Require a
+    # maintainer to opt in by applying the 'ai-review' label. External
+    # contributors cannot add labels, so only a maintainer can authorize the
+    # spend. Until the label is present the job is skipped and 0 tokens are used.
+    # Also skip Dependabot (isolated secret store → empty token → always fails).
+    if: >-
+      github.event.pull_request.user.login != 'dependabot[bot]'
+      && contains(github.event.pull_request.labels.*.name, 'ai-review')
     runs-on: ubuntu-latest
     steps:
       # Check out the BASE repo only (the trusted default for pull_request_target).

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -17,10 +17,15 @@ name: PR Review
 # content, contained by the restricted, read-only toolset.
 on:
   pull_request_target:
-    # opened: first review. synchronize: re-review when the PR gets new commits.
-    # reopened: lets a maintainer re-run the review by closing+reopening the PR
-    # (the only re-trigger lever, since this is a privileged target workflow).
-    types: [opened, synchronize, reopened]
+    # opened: one-time auto-review on a new PR.
+    # reopened: the re-trigger lever — a maintainer re-runs the review by
+    #   closing+reopening the PR (a privileged target workflow can't be re-run
+    #   any other way on an already-open PR).
+    # NOT synchronize: re-review on every push would double up with the explicit
+    #   @claude pings that the auto-pr / auto-issue loops already post per push,
+    #   producing two Claude reviews per commit. Re-reviews are driven explicitly
+    #   (auto-pr's ping, a manual @claude, or close+reopen) instead.
+    types: [opened, reopened]
 
 permissions:
   contents: read

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -17,7 +17,10 @@ name: PR Review
 # content, contained by the restricted, read-only toolset.
 on:
   pull_request_target:
-    types: [opened]
+    # opened: first review. synchronize: re-review when the PR gets new commits.
+    # reopened: lets a maintainer re-run the review by closing+reopening the PR
+    # (the only re-trigger lever, since this is a privileged target workflow).
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,8 +19,27 @@ permissions:
 
 jobs:
   claude:
+    # Trust gate (load-bearing): this job runs from the default branch WITH secrets,
+    # contents: write, and a checkout of the PR head — comment/issue events are NOT
+    # protected by the fork-PR "require approval" gate, so without this check ANY
+    # non-bot user who types "@claude" could trigger a privileged, write-capable run.
+    # Restrict triggering to the repo owner / org members / collaborators. The
+    # association field differs per event, and only the firing event's field is set,
+    # so we OR across them (the others are empty strings and never match).
     if: |
-      github.event.sender.type != 'Bot' && (
+      github.event.sender.type != 'Bot'
+      && (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR' ||
+        github.event.review.author_association == 'OWNER' ||
+        github.event.review.author_association == 'MEMBER' ||
+        github.event.review.author_association == 'COLLABORATOR' ||
+        github.event.issue.author_association == 'OWNER' ||
+        github.event.issue.author_association == 'MEMBER' ||
+        github.event.issue.author_association == 'COLLABORATOR'
+      )
+      && (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -23,27 +23,36 @@ jobs:
     # contents: write, and a checkout of the PR head — comment/issue events are NOT
     # protected by the fork-PR "require approval" gate, so without this check ANY
     # non-bot user who types "@claude" could trigger a privileged, write-capable run.
-    # Restrict triggering to the repo owner / org members / collaborators. The
-    # association field differs per event, and only the firing event's field is set,
-    # so we OR across them (the others are empty strings and never match).
+    #
+    # The association MUST be checked against the actor of the *firing* event — the
+    # commenter for *_comment, the reviewer for pull_request_review, the issue
+    # author for issues. An issue_comment payload carries BOTH `comment` and
+    # `issue`, so a blanket OR across them lets an untrusted commenter pass via the
+    # trusted issue author on a maintainer-owned issue/PR. So each event clause
+    # binds its own actor's association inline.
     if: |
       github.event.sender.type != 'Bot'
       && (
-        github.event.comment.author_association == 'OWNER' ||
-        github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.author_association == 'COLLABORATOR' ||
-        github.event.review.author_association == 'OWNER' ||
-        github.event.review.author_association == 'MEMBER' ||
-        github.event.review.author_association == 'COLLABORATOR' ||
-        github.event.issue.author_association == 'OWNER' ||
-        github.event.issue.author_association == 'MEMBER' ||
-        github.event.issue.author_association == 'COLLABORATOR'
-      )
-      && (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+        (github.event_name == 'issue_comment'
+          && contains(github.event.comment.body, '@claude')
+          && (github.event.comment.author_association == 'OWNER'
+            || github.event.comment.author_association == 'MEMBER'
+            || github.event.comment.author_association == 'COLLABORATOR')) ||
+        (github.event_name == 'pull_request_review_comment'
+          && contains(github.event.comment.body, '@claude')
+          && (github.event.comment.author_association == 'OWNER'
+            || github.event.comment.author_association == 'MEMBER'
+            || github.event.comment.author_association == 'COLLABORATOR')) ||
+        (github.event_name == 'pull_request_review'
+          && contains(github.event.review.body, '@claude')
+          && (github.event.review.author_association == 'OWNER'
+            || github.event.review.author_association == 'MEMBER'
+            || github.event.review.author_association == 'COLLABORATOR')) ||
+        (github.event_name == 'issues'
+          && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))
+          && (github.event.issue.author_association == 'OWNER'
+            || github.event.issue.author_association == 'MEMBER'
+            || github.event.issue.author_association == 'COLLABORATOR'))
       )
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Hardening so that **untrusted fork PRs / issues cannot consume Claude tokens without an explicit maintainer opt-in**.

## 1. `claude.yml` — restrict `@claude` to trusted users

`@claude` runs on comment/issue events, which are **privileged** (default-branch context, secrets, `contents: write`, PR-head checkout) and are **not** covered by the fork-PR approval gate. The old `if:` only required `sender != Bot` + the text `@claude`, so **any non-bot user** could trigger a secrets-bearing run.

Added an **author-association gate**: the job runs only when the trigger comes from `OWNER` / `MEMBER` / `COLLABORATOR`. Pure expression context — no `run:` interpolation added.

## 2. `claude-review.yml` — gate the review behind a maintainer label

`pull_request_target` is privileged (carries secrets) and is **not** gated by the fork-PR "require approval" prompt (that's the `pull_request` event only). So the review would **auto-run and spend tokens on any fork PR from anyone**.

Fix: the `review` job now requires a maintainer-applied **`ai-review`** label (`contains(pull_request.labels.*.name, 'ai-review')`). External contributors can't add labels, so only a maintainer authorizes the spend. Unlabeled fork PRs **skip the job → 0 tokens**. Trigger is `[opened, reopened, labeled]`; applying the label fires the review.

**No `synchronize`:** would double up with the `@claude` pings the `auto-pr`/`auto-issue` loops already post per push (two Claude reviews per commit). Re-reviews stay explicit.

Builds on #31 (no PR-head checkout; read-only `gh pr diff/view/comment` toolset).

## Out of scope (flagged separately)

`issue-triage.yml` runs Claude on **every issue from anyone** (`allowed_non_write_users: "*"`) — a separate token vector being decided on its own.

## This PR's own red check

`review` will 401 (`Invalid OIDC token`) because the PR edits `claude-review.yml` — by-design workflow-tampering protection, not a required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)