### PR TITLE
chore(docker): harden HTTP/SSE deploy and isolate mcp-proxy dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,16 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements first for better caching
-COPY requirements.txt .
+COPY requirements.txt requirements-http.txt ./
 
-# Install Python dependencies
-RUN pip install --no-cache-dir -r requirements.txt
+# Install Python dependencies. The default image (stdio / Xiaozhi) installs only
+# requirements.txt. The HTTP/SSE image (docker-compose.http.yml) passes
+# INSTALL_HTTP=true to additionally install mcp-proxy from requirements-http.txt.
+ARG INSTALL_HTTP=false
+RUN pip install --no-cache-dir -r requirements.txt \
+    && if [ "$INSTALL_HTTP" = "true" ]; then \
+        pip install --no-cache-dir -r requirements-http.txt; \
+    fi
 
 # Copy source code
 COPY src/ ./src/

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY requirements.txt requirements-http.txt ./
 # INSTALL_HTTP=true to additionally install mcp-proxy from requirements-http.txt.
 ARG INSTALL_HTTP=false
 RUN pip install --no-cache-dir -r requirements.txt \
-    && if [ "$INSTALL_HTTP" = "true" ]; then \
+    && if [ "$INSTALL_HTTP" = "true" ] || [ "$INSTALL_HTTP" = "1" ]; then \
         pip install --no-cache-dir -r requirements-http.txt; \
     fi
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,9 @@ By default the server speaks **stdio**, which means the MCP client has to spawn 
 
 ### Deploy
 
-1. Make sure `mcp-proxy` is in `requirements.txt` (it is, as of this version).
+1. `mcp-proxy` is installed automatically when you build the HTTP image — it
+   lives in `requirements-http.txt` and the provided compose file sets the
+   `INSTALL_HTTP=true` build arg (it is not in the default stdio/Xiaozhi image).
 2. Use the provided `docker-compose.http.yml`:
 
 ```bash

--- a/docker-compose.http.yml
+++ b/docker-compose.http.yml
@@ -9,27 +9,33 @@
 # file when you want a long-running, network-accessible MCP server.
 #
 # Prerequisites:
-#   - mcp-proxy added to requirements.txt (already done in this PR)
+#   - The HTTP image installs mcp-proxy from requirements-http.txt via the
+#     INSTALL_HTTP=true build arg below (it is NOT in the default image).
 #   - A reverse proxy in front (DSM, Nginx, Traefik, Caddy...) terminating
 #     TLS, since most MCP clients only accept HTTPS endpoints.
 #
 # Usage:
-#   1. Copy this file to docker-compose.http.yml (or use -f docker-compose.http.yml)
-#   2. Edit the environment block with your credentials (or use settings.json)
-#   3. docker compose -f docker-compose.http.yml up -d --build
-#   4. Point your reverse proxy at http://<host>:8765
-#   5. In your MCP client, add a custom connector:
+#   1. Edit the environment block below with your credentials (or use settings.json)
+#   2. docker compose -f docker-compose.http.yml up -d --build
+#   3. Point your reverse proxy at http://127.0.0.1:8765
+#   4. In your MCP client, add a custom connector:
 #        URL: https://your-domain.example.com/sse
 #
 # Security note:
-#   mcp-proxy does NOT provide server-side authentication. Put it behind a
-#   reverse proxy that adds authentication (Basic Auth, mTLS, OAuth2 proxy,
-#   IP allow-list) before exposing it to anything other than a trusted LAN
-#   or VPN.
+#   mcp-proxy does NOT provide server-side authentication. The port below is
+#   published on 127.0.0.1 only, so it is reachable solely from a reverse proxy
+#   on this host (DSM/Nginx/etc.) — never directly from the LAN/internet. Keep
+#   that reverse proxy adding authentication (Basic Auth, mTLS, OAuth2 proxy,
+#   IP allow-list). A reverse proxy running in another container should reach
+#   this service over the Docker network rather than the published port.
 
 services:
   synology-mcp-http:
-    build: .
+    build:
+      context: .
+      # Install the HTTP/SSE transport deps (mcp-proxy) into this image only.
+      args:
+        INSTALL_HTTP: "true"
     container_name: synology-mcp-http
     # mcp-proxy spawns `python main.py` as a stdio child and exposes it
     # over SSE/Streamable HTTP on port 8765.
@@ -43,7 +49,9 @@ services:
       - "python"
       - "main.py"
     ports:
-      - "8765:8765"
+      # Publish on loopback only — a same-host reverse proxy (DSM/Nginx) reaches
+      # it; the unauthenticated proxy is never directly exposed to the network.
+      - "127.0.0.1:8765:8765"
     environment:
       - XDG_CONFIG_HOME=/home/mcpuser/.config
       # Required: Synology NAS connection
@@ -52,7 +60,9 @@ services:
       - SYNOLOGY_PASSWORD=your_password
       # Optional
       - AUTO_LOGIN=true
-      - VERIFY_SSL=false
+      # Default to verifying the NAS TLS cert. Set to false only if your DSM
+      # uses a self-signed cert you can't add to the trust store.
+      - VERIFY_SSL=true
       - DEBUG=false
       - LOG_LEVEL=INFO
       - ENABLE_XIAOZHI=false

--- a/requirements-http.txt
+++ b/requirements-http.txt
@@ -1,0 +1,7 @@
+# HTTP/SSE transport dependencies — used only by docker-compose.http.yml.
+# These are NOT installed in the default stdio/Xiaozhi image; the Dockerfile
+# installs them only when built with INSTALL_HTTP=true.
+#
+# Upper bound: mcp-proxy is young and pre-1.0, so pin below the next major to
+# avoid a breaking change silently breaking HTTP deployments.
+mcp-proxy>=0.7.0,<1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,10 @@ requests
 mcp>=1.27.2
 python-dotenv
 websockets>=16.0
-mcp-proxy>=0.7.0
+
+# HTTP/SSE transport (mcp-proxy) is intentionally NOT here — it's only needed
+# for docker-compose.http.yml and lives in requirements-http.txt, installed
+# only when building the HTTP image (INSTALL_HTTP=true).
 
 # Testing dependencies
 pytest>=9.0.3


### PR DESCRIPTION
## Summary
- **Publish the HTTP port on `127.0.0.1` only** (`127.0.0.1:8765:8765`), so the unauthenticated `mcp-proxy` is reachable solely from a same-host reverse proxy (DSM/Nginx), never directly from the LAN/internet. (`--host=0.0.0.0` stays — that's the bind *inside* the container.)
- **Isolate `mcp-proxy`**: moved out of `requirements.txt` into a new `requirements-http.txt`; the Dockerfile installs it only when built with `INSTALL_HTTP=true` (a build arg the HTTP compose sets). The default stdio/Xiaozhi image no longer ships it.
- **Pin `mcp-proxy>=0.7.0,<1.0`** (pre-1.0 package; avoid silent breaking changes).
- **Default `VERIFY_SSL=true`** in the HTTP compose example, with a comment.
- **Fix docs**: the self-referential "copy this file to docker-compose.http.yml" usage step, the prerequisites note, and the README deploy step now describe the build-arg install.

## Why
Follow-ups from the automated review on #25 (merged) — non-blocking hardening of the opt-in HTTP/SSE deployment.

## Test plan
- [x] `docker compose -f docker-compose.http.yml config` validates.
- [x] No Python source changed; test suite passes (23 passed, 40 integration skipped, 0 failed).
- [x] Verified no stale references: `mcp-proxy` gone from `requirements.txt`, no raw `8765:8765` publish.
- [ ] Manual: build the HTTP image (`--build`) and confirm `mcp-proxy` is present and reachable via a reverse proxy → `127.0.0.1:8765`.

Closes #34