### PR TITLE
fix(auth): observable relogin import failure + concurrency-safe 119 recovery

### DIFF
--- a/src/auth/synology_auth.py
+++ b/src/auth/synology_auth.py
@@ -1,6 +1,7 @@
 # src/synology_auth.py - Simple Synology authentication utilities
 
 import logging
+import threading
 from typing import Any, Callable, Dict, Optional, Tuple
 
 import requests
@@ -42,6 +43,9 @@ class SynologyAuth:
         # (base_url, session_id, syno_token). Lets the caller (e.g. mcp_server)
         # resync any cached session state with the refreshed SID.
         self.on_relogin: Optional[Callable[[str, Optional[str], Optional[str]], None]] = None
+        # Serializes relogin() so concurrent DSM-119 recoveries don't each open a
+        # separate session (which would leak the orphaned SIDs on the NAS).
+        self._relogin_lock = threading.Lock()
         # Register this instance for cross-module discovery (see _AUTH_REGISTRY).
         _AUTH_REGISTRY[self.base_url] = self
 
@@ -109,7 +113,7 @@ class SynologyAuth:
         """Authenticate specifically for Download Station."""
         return self.login_with_session(username, password, "DownloadStation")
 
-    def relogin(self) -> bool:
+    def relogin(self, stale_session_id: Optional[str] = None) -> bool:
         """Re-authenticate using credentials cached from the last successful login.
 
         Returns True on success, False if no credentials are cached or login fails.
@@ -117,20 +121,34 @@ class SynologyAuth:
         found"), which happens when the server-side session expires (typically
         after ~1h of inactivity for SYNO.Core.* APIs). Without this, the client's
         SID stays dead until the process restarts.
+
+        Concurrency-safe: the login is serialized by a per-instance lock. If
+        `stale_session_id` is given and another thread already refreshed the
+        session while this caller waited for the lock, the relogin is skipped
+        (the current session is already valid) — so simultaneous 119s open a
+        single new session instead of one per caller.
         """
         if not self._credentials:
             return False
-        username, password = self._credentials
-        result = self.login_with_session(username, password, self.current_session_type)
-        success = bool(result.get("success"))
-        if success and self.on_relogin is not None:
-            # Notify the caller so it can resync cached session state with the
-            # new SID. A callback failure must never break the relogin path.
-            try:
-                self.on_relogin(self.base_url, self.current_session_id, self.current_syno_token)
-            except Exception as exc:  # pragma: no cover - defensive
-                logger.warning("on_relogin callback failed for %s: %s", self.base_url, exc)
-        return success
+        with self._relogin_lock:
+            # Another thread already recovered the session under the lock.
+            if (
+                stale_session_id is not None
+                and self.current_session_id is not None
+                and self.current_session_id != stale_session_id
+            ):
+                return True
+            username, password = self._credentials
+            result = self.login_with_session(username, password, self.current_session_type)
+            success = bool(result.get("success"))
+            if success and self.on_relogin is not None:
+                # Notify the caller so it can resync cached session state with the
+                # new SID. A callback failure must never break the relogin path.
+                try:
+                    self.on_relogin(self.base_url, self.current_session_id, self.current_syno_token)
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.warning("on_relogin callback failed for %s: %s", self.base_url, exc)
+            return success
 
     def logout(
         self, session_id: Optional[str] = None, session_type: Optional[str] = None

--- a/src/utils/synology_api.py
+++ b/src/utils/synology_api.py
@@ -1,26 +1,36 @@
 # src/utils/synology_api.py - Shared API client for all Synology modules
 
+import logging
 from typing import Any, Dict, Optional, Tuple
 
 import requests
 
+logger = logging.getLogger(__name__)
 
-def _try_relogin(base_url: str) -> Tuple[Optional[str], Optional[str]]:
+
+def _try_relogin(
+    base_url: str, stale_session_id: Optional[str] = None
+) -> Tuple[Optional[str], Optional[str]]:
     """Lookup the SynologyAuth registered for this URL and trigger a relogin.
 
     Used internally by SynologyAPIClient.request() to silently recover from
     DSM error 119 (SID expired). Returns (new_session_id, new_syno_token) on
     success, (None, None) if no auth instance is registered for this URL or
-    if the relogin attempt fails.
+    if the relogin attempt fails. `stale_session_id` is the SID that just got
+    the 119; it lets concurrent recoveries collapse into a single relogin.
 
     Import is deferred to runtime to avoid a circular import (auth → utils).
     """
     try:
         from auth.synology_auth import get_auth_for_url
-    except ImportError:
+    except ImportError as exc:
+        # Deferred to dodge a circular import; a real failure here (e.g. a
+        # syntax error introduced in synology_auth) would otherwise silently
+        # leave the caller stuck on the 119. Log it so it's observable.
+        logger.warning("Cannot recover from DSM error 119 — auth module unavailable: %s", exc)
         return (None, None)
     auth = get_auth_for_url(base_url)
-    if auth is None or not auth.relogin():
+    if auth is None or not auth.relogin(stale_session_id):
         return (None, None)
     return (auth.current_session_id, auth.current_syno_token)
 
@@ -79,7 +89,7 @@ class SynologyAPIClient:
         # this base_url. If it succeeds, refresh local SID/token and retry once.
         # If no auth is registered, return the original 119 to the caller.
         if not result.get("success") and result.get("error", {}).get("code") == 119:
-            new_sid, new_token = _try_relogin(self.base_url)
+            new_sid, new_token = _try_relogin(self.base_url, self.session_id)
             if new_sid:
                 self.session_id = new_sid
                 self.syno_token = new_token

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -235,4 +235,34 @@ def test_auth_url_construction():
         assert auth.base_url == expected_base
         print(f"✅ URL '{url}' → '{auth.base_url}'")
 
+
+def test_relogin_without_credentials_returns_false():
+    """relogin() is a no-op (False) before any successful login caches creds."""
+    from auth.synology_auth import SynologyAuth
+
+    auth = SynologyAuth("https://nas.example.test:5001")
+    assert auth._credentials is None
+    assert auth.relogin() is False
+
+
+def test_relogin_skips_when_session_already_refreshed():
+    """Concurrent DSM-119 recovery: if another caller already refreshed the
+    session while this one waited on the lock, relogin() must NOT log in again
+    (which would open a second, orphaned session)."""
+    from auth.synology_auth import SynologyAuth
+
+    auth = SynologyAuth("https://nas.example.test:5001")
+    auth._credentials = ("user", "pass")
+    # Simulate another thread having already re-authenticated under the lock.
+    auth.current_session_id = "NEW_SID"
+
+    def _fail(*args, **kwargs):
+        raise AssertionError("login_with_session should not be called on a no-op relogin")
+
+    auth.login_with_session = _fail  # type: ignore[assignment]
+
+    # This caller saw OLD_SID get the 119; current is already NEW_SID → skip.
+    assert auth.relogin(stale_session_id="OLD_SID") is True
+    assert auth.current_session_id == "NEW_SID"
+
     print("✅ URL construction tests passed")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -235,6 +235,8 @@ def test_auth_url_construction():
         assert auth.base_url == expected_base
         print(f"✅ URL '{url}' → '{auth.base_url}'")
 
+    print("✅ URL construction tests passed")
+
 
 def test_relogin_without_credentials_returns_false():
     """relogin() is a no-op (False) before any successful login caches creds."""
@@ -264,5 +266,3 @@ def test_relogin_skips_when_session_already_refreshed():
     # This caller saw OLD_SID get the 119; current is already NEW_SID → skip.
     assert auth.relogin(stale_session_id="OLD_SID") is True
     assert auth.current_session_id == "NEW_SID"
-
-    print("✅ URL construction tests passed")


### PR DESCRIPTION
## Summary
- **Log the swallowed `ImportError` in `_try_relogin`** (`src/utils/synology_api.py`). The deferred import (kept to avoid a circular import) was silently caught, so a genuine `ImportError` would leave the caller stuck on the 119 with no signal. Now it logs a warning.
- **Make `relogin()` concurrency-safe** (`src/auth/synology_auth.py`). Two simultaneous 119s used to each open a separate DSM session, orphaning SIDs on the NAS. `relogin()` now serializes on a per-instance `threading.Lock` and, given the SID that hit the 119, **skips re-login if another caller already refreshed the session** — so concurrent recoveries collapse into a single new session.
- **Two no-NAS unit tests** for the guard (no-credentials no-op; skip-when-already-refreshed).

## Why
Follow-ups from the automated review on #27 (merged). Minor robustness items on the DSM error-119 auto-relogin.

## Test plan
- [x] Full suite passes: **25 passed, 40 skipped (real-NAS), 0 failed**.
- [x] Regression test verified by reverting — `test_relogin_skips_when_session_already_refreshed` **fails** with the guard disabled, passes with it.
- [x] Backward compatible: `relogin()`'s new `stale_session_id` arg defaults to `None` (old behavior for any other caller).

Closes #35