### PR TITLE
release: 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+## [1.4.2] - 2026-06-12
+
+### Added
+- Optional HTTP/SSE transport for remote deployments via `docker-compose.http.yml` (mcp-proxy). The extra dependency is isolated in `requirements-http.txt` and only installed when the image is built with `INSTALL_HTTP=1`/`true`; the default stdio/Xiaozhi image is unchanged. (#25, #36)
+
+### Fixed
+- Transparent recovery from DSM error 119 ("SID not found"). When a server-side session expires — typically after ~1h of inactivity on `SYNO.Core.*` APIs — `SynologyAPIClient` now re-authenticates with the cached credentials and retries the call once instead of failing until the process restarts. The relogin is concurrency-safe (serialized per NAS, so simultaneous 119s collapse into a single new session rather than leaking orphaned SIDs) and resyncs `mcp_server`'s cached SID/token and lazily-built service instances, so a later logout targets the live session. A failed auth-module import on the recovery path is now logged instead of silently swallowed. (#27, #37)
+
+### Changed
+- Hardened the HTTP/SSE Docker build and isolated the mcp-proxy dependency from the core image. (#36)
+- Bumped `mcp` to `>=1.27.2` and `pytest-asyncio` to `>=1.4.0`. (#26, #28)
+- CI: gate `@claude` and PR-review workflows to trusted users, support fork PRs via `pull_request_target`, and skip Dependabot/fork runs where appropriate. (#29–#33)
+
 ## [1.4.1] - 2026-05-05
 
 ### Fixed


### PR DESCRIPTION
Maintenance release cut from \`main\` after verifying the branch end-to-end.

## Verification
- Full test suite on a clean env matching the shipping pins (mcp 1.27.2, websockets 16.0, pytest 9.0.3): **60 passed, 3 skipped**. The 2 local "failures" are dev-machine artifacts (a real \`.env\` leaking creds into a config-isolation test, and a \`real_nas\` strict-assert test) — both pass/skip on a clean checkout and are unchanged since 1.4.1.
- Live smoke test: server boots, auto-logs in to the NAS, registers 47 tools, and \`synology_status\` / \`list_shares\` return real data end-to-end over MCP stdio.

## Changes
### Added
- Optional HTTP/SSE transport via \`docker-compose.http.yml\` (mcp-proxy), isolated in \`requirements-http.txt\`. (#25, #36)

### Fixed
- Transparent DSM error-119 (expired SID) recovery: concurrency-safe relogin + session resync. (#27, #37)

### Changed
- Docker HTTP/SSE hardening (#36), dependency bumps (#26, #28), CI gating (#29–#33).