### PR TITLE
feat(container): add Container Manager tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,97 @@ docker-compose up
 - **`synology_system_log`** - Get recent system log entries
 - **`synology_health_summary`** - Aggregate system info, utilization, disk health, and volume status
 
+### 🐳 Container Manager
+- **`synology_container_list`** - List Container Manager containers
+  - `offset` (optional): Pagination offset
+  - `limit` (optional): Maximum containers to return
+  - `container_type` (optional): Container filter (default: `all`)
+- **`synology_container_get`** - Get a Container Manager container
+  - `name` (required): Container name
+- **`synology_container_start`** - Start a Container Manager container
+  - `name` (required): Container name
+- **`synology_container_stop`** - Stop a Container Manager container
+  - `name` (required): Container name
+- **`synology_container_restart`** - Restart a Container Manager container
+  - `name` (required): Container name
+- **`synology_container_delete`** - Delete a Container Manager container
+  - `name` (required): Container name
+  - `force` (optional): Force deletion (default: false)
+  - `preserve_profile` (optional): Preserve Synology container profile (default: true)
+- **`synology_container_logs`** - Get Container Manager container logs
+  - `name` (required): Container name
+  - `since` (optional): Log start time/filter
+  - `timestamps` (optional): Include log timestamps (default: false)
+- **`synology_container_resource`** - Get real-time resource usage for a Container Manager container
+  - `name` (required): Container name
+- **`synology_container_project_list`** - List Container Manager projects
+- **`synology_container_project_get`** - Get a Container Manager project
+  - `name` (required): Project name
+- **`synology_container_project_create`** - Create a Container Manager project
+  - `name` (required): Project name
+  - `share_path` (required): Project folder path on the NAS
+  - `content` (required): Docker Compose YAML content
+  - `enable_service_portal` (optional): Enable Synology service portal (default: false)
+  - `service_portal_name` (optional): Service portal name
+  - `service_portal_port` (optional): Service portal port
+  - `service_portal_protocol` (optional): Service portal protocol (default: `http`)
+- **`synology_container_project_update`** - Update a Container Manager project
+  - `name` (required): Project name
+  - `content` (required): Docker Compose YAML content
+  - `enable_service_portal` (optional): Enable Synology service portal
+  - `service_portal_name` (optional): Service portal name
+  - `service_portal_port` (optional): Service portal port
+  - `service_portal_protocol` (optional): Service portal protocol
+- **`synology_container_project_start`** - Start a Container Manager project
+  - `name` (required): Project name
+- **`synology_container_project_stop`** - Stop a Container Manager project
+  - `name` (required): Project name
+- **`synology_container_project_restart`** - Restart a Container Manager project
+  - `name` (required): Project name
+- **`synology_container_project_build`** - Build a Container Manager project
+  - `name` (required): Project name
+- **`synology_container_project_clean`** - Clean a Container Manager project
+  - `name` (required): Project name
+- **`synology_container_project_delete`** - Delete a Container Manager project
+  - `name` (required): Project name
+- **`synology_container_image_list`** - List Container Manager images
+  - `offset` (optional): Pagination offset
+  - `limit` (optional): Maximum images to return
+  - `show_dsm` (optional): Include DSM images (default: false)
+- **`synology_container_image_get`** - Get a Container Manager image
+  - `name` (required): Image repository name
+  - `tag` (optional): Image tag (default: `latest`)
+- **`synology_container_image_delete`** - Delete a Container Manager image
+  - `name` (required): Image repository name
+  - `tag` (optional): Image tag (default: `latest`)
+- **`synology_container_image_pull`** - Pull a Container Manager image
+  - `repository` (required): Image repository name
+  - `tag` (optional): Image tag (default: `latest`)
+- **`synology_container_registry_list`** - List Container Manager registries
+- **`synology_container_registry_search`** - Search Container Manager registries
+  - `query` (required): Image search query
+  - `offset` (optional): Pagination offset
+  - `limit` (optional): Maximum results to return
+- **`synology_container_registry_tags`** - List tags for a registry image
+  - `repository` (required): Image repository name
+  - `offset` (optional): Pagination offset
+  - `limit` (optional): Maximum tags to return
+- **`synology_container_registry_download`** - Download a registry image
+  - `repository` (required): Image repository name
+  - `tag` (optional): Image tag (default: `latest`)
+- **`synology_container_network_list`** - List Container Manager networks
+- **`synology_container_network_get`** - Get a Container Manager network
+  - `name` (required): Network name
+- **`synology_container_network_create`** - Create a Container Manager network
+  - `name` (required): Network name
+  - `driver` (optional): Network driver (default: `bridge`)
+  - `subnet` (optional): Subnet CIDR
+  - `gateway` (optional): Gateway IP
+  - `ip_range` (optional): Allocatable IP range CIDR
+  - `enable_ipv6` (optional): Enable IPv6 (default: false)
+- **`synology_container_network_delete`** - Delete a Container Manager network
+  - `name` (required): Network name
+
 ### 📦 NFS Management
 - **`synology_nfs_status`** - Get NFS service status and configuration
 - **`synology_nfs_enable`** - Enable or disable the NFS service
@@ -382,7 +473,7 @@ docker-compose up
 
 For Claude Code, Claude Desktop, and claude.ai users, this repo ships an Anthropic Agent Skill that teaches Claude how to use the MCP tools effectively — picking the right tool, targeting the right NAS in multi-NAS setups, preferring aggregate health checks over fan-out calls, and using correct path conventions.
 
-The skill lives at [`skills/synology-nas/`](skills/synology-nas/) and uses progressive disclosure across six domains (auth, files, downloads, health, shares/NFS, user management).
+The skill lives at [`skills/synology-nas/`](skills/synology-nas/) and uses progressive disclosure across seven domains (auth, files, downloads, health, containers, shares/NFS, user management).
 
 **Install:**
 

--- a/README.md
+++ b/README.md
@@ -392,7 +392,6 @@ docker-compose up
 - **`synology_container_logs`** - Get Container Manager container logs
   - `name` (required): Container name
   - `since` (optional): Log start time/filter
-  - `timestamps` (optional): Include log timestamps (default: false)
 - **`synology_container_resource`** - Get real-time resource usage for a Container Manager container
   - `name` (required): Container name
 - **`synology_container_project_list`** - List Container Manager projects

--- a/skills/synology-nas/SKILL.md
+++ b/skills/synology-nas/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: synology-nas
-description: Use this skill for ANY task on a Synology NAS via the mcp-server-synology MCP — managing files and folders on the NAS, searching NAS shares, reading or creating NAS files, running Download Station tasks (torrents, magnets, downloads), checking NAS health (disks, SMART, volumes, RAID, SHR, UPS, CPU/memory utilization), creating shared folders, configuring NFS exports, and managing NAS users, groups, or share permissions. Triggers on "synology", "NAS", "DSM", "DiskStation", "DS220+/DS920+/etc", "Download Station", "/volume1", and any NAS-share path. Use even when the user just says "my NAS" or names a model number without saying "Synology". Distinct from the lifehacker-cert skill, which only handles SSL certs on one specific NAS — this skill is for general NAS operation.
+description: Use this skill for ANY task on a Synology NAS via the mcp-server-synology MCP — managing files and folders on the NAS, searching NAS shares, reading or creating NAS files, running Download Station tasks (torrents, magnets, downloads), checking NAS health (disks, SMART, volumes, RAID, SHR, UPS, CPU/memory utilization), managing Container Manager containers/projects/images/registries/networks, creating shared folders, configuring NFS exports, and managing NAS users, groups, or share permissions. Triggers on "synology", "NAS", "DSM", "DiskStation", "DS220+/DS920+/etc", "Download Station", "Container Manager", "Docker", "container", "/volume1", and any NAS-share path. Use even when the user just says "my NAS" or names a model number without saying "Synology". Distinct from the lifehacker-cert skill, which only handles SSL certs on one specific NAS — this skill is for general NAS operation.
 ---
 
 # Synology NAS
 
-This skill teaches you how to use the `mcp-server-synology` MCP effectively. The MCP exposes ~50 tools across six domains; the trick is picking the right tool, targeting the right NAS, and not exploding a single user request into a dozen redundant calls.
+This skill teaches you how to use the `mcp-server-synology` MCP effectively. The MCP exposes ~80 tools across seven domains; the trick is picking the right tool, targeting the right NAS, and not exploding a single user request into a dozen redundant calls.
 
 ## Mental model
 
@@ -47,6 +47,7 @@ When the user asks about… → read…
 | list/find/search files, read/create/delete/move/rename files & folders, shares | filestation | [references/files.md](references/files.md) |
 | download, torrent, magnet, BT, transmission-style task | Download Station | [references/downloads.md](references/downloads.md) |
 | disks, SMART, RAID/SHR, volume, UPS, CPU/memory utilization, system info, "is the NAS healthy" | health | [references/health.md](references/health.md) |
+| containers, Docker, compose projects, images, registries, networks, logs, resource usage | Container Manager | [references/containers.md](references/containers.md) |
 | NFS, share permissions, "let host X mount", create share | shares & NFS | [references/shares-nfs.md](references/shares-nfs.md) |
 | users, groups, permissions, "add user", "remove from group" | user management | [references/users.md](references/users.md) |
 
@@ -64,6 +65,7 @@ When in doubt about a destructive action, list/inspect first:
 
 - Before `delete`: `get_file_info` to confirm the path resolves to what you think.
 - Before `ds_delete_tasks`: `ds_list_tasks` to confirm the IDs.
+- Before `synology_container_delete`, `synology_container_project_delete`, `synology_container_image_delete`, or `synology_container_network_delete`: inspect/list the target first.
 - Before `synology_delete_user`: `synology_get_user` to confirm the account.
 
 This is a real NAS with real data — there is no "undo" for these tools.
@@ -80,6 +82,23 @@ Auto-login is on by default — the server logs in to every configured NAS at st
 
 If the user says "list shares and then list the photos folder," do those two calls — don't preface them with a discovery dance. Discovery (`synology_list_nas`/`synology_status`) is for when targeting or auth is genuinely unclear, not as a ritual before every request.
 
+### Container Manager: GHCR and runtime DNS
+
+GHCR pulls:
+1. `synology_container_registry_list`; require `using: GitHub Container Registry` for `ghcr.io/...`.
+2. On `2202` or `docker.io/ghcr.io/...`, switch registry in DSM, then `synology_container_registry_download`.
+3. Try `owner/image` first with GHCR active; try `ghcr.io/owner/image` only if needed.
+4. Wait after successful download; confirm with `synology_container_image_list`.
+5. If project `start` fails, run `synology_container_project_build` for DSM logs/start behavior.
+
+Runtime DNS:
+- Restart loop: inspect `synology_container_logs`.
+- Logs show `Temporary failure in name resolution` and NAS has internet: use `network_mode: host` for single-port apps; remove `ports:`.
+- Avoid `dns:` first; Synology compose may accept it then fail with `2202`.
+
+Optional companion services: skip when README says optional and main app works; add when user needs feature.
+
+
 ## Anti-patterns to avoid
 
 - **Calling `synology_login` reflexively.** Auto-login almost always handled it.
@@ -87,6 +106,7 @@ If the user says "list shares and then list the photos folder," do those two cal
 - **Inventing paths like `/Documents/foo` or `~/photos`.** Real paths start with `/volume1/`. List the parent if unsure.
 - **Picking a NAS in a multi-NAS setup without confirmation.** Ask which one.
 - **Confusing "shares" with "files."** A *share* is the top-level mount (Photos, video, homes); creating one is an admin action and lives in `synology_create_share` (see shares-nfs.md). Creating a *folder under* a share is `create_directory`.
+- **Treating containers as files.** Container Manager tools use names/repositories/projects, not NAS paths, except project `share_path`.
 - **Bulk operations without verification.** If the user asks to delete "all old downloads," list them, summarize what you're about to delete, and confirm before calling `ds_delete_tasks` or `delete`.
 
 ## Example: a typical session

--- a/skills/synology-nas/evals/evals.json
+++ b/skills/synology-nas/evals/evals.json
@@ -44,6 +44,20 @@
         {"text": "Plan distinguishes between deleting the task entry and deleting the downloaded files on disk (mentions that files stay unless separately removed via the delete tool)"},
         {"text": "Plan offers a confirmation step / summary before bulk deletion rather than acting blindly"}
       ]
+    },
+    {
+      "id": 3,
+      "name": "container-restart-safety",
+      "prompt": "watchtower on my Synology looks wedged. plan first: how would you inspect it, restart it, and check whether it came back cleanly? don't actually call anything yet.",
+      "expected_output": "A plan that uses Container Manager tools: inspect/list the watchtower container first, restart it by name, then check logs and/or resource/status afterward. It should not treat watchtower as a file path, image repository, or Download Station task.",
+      "files": [],
+      "assertions": [
+        {"text": "Plan uses synology_container_get or synology_container_list before restarting"},
+        {"text": "Plan uses synology_container_restart with name=\"watchtower\""},
+        {"text": "Plan checks synology_container_logs and/or synology_container_resource after restart"},
+        {"text": "Plan does NOT use file tools or Download Station tools for a container restart"},
+        {"text": "Plan handles multi-NAS targeting with nas_name when needed"}
+      ]
     }
   ]
 }

--- a/skills/synology-nas/references/containers.md
+++ b/skills/synology-nas/references/containers.md
@@ -1,0 +1,89 @@
+# Container Manager
+
+## Tools
+
+| Tool | Purpose | Required |
+|------|---------|----------|
+| `synology_container_list` | List containers | — |
+| `synology_container_get` | Inspect one container | `name` |
+| `synology_container_start` | Start a container | `name` |
+| `synology_container_stop` | Stop a container | `name` |
+| `synology_container_restart` | Restart a container | `name` |
+| `synology_container_delete` | Delete a container | `name` |
+| `synology_container_logs` | Read container logs | `name` |
+| `synology_container_resource` | Current resource usage | `name` |
+| `synology_container_project_*` | List/get/create/update/start/stop/restart/build/clean/delete compose projects | varies |
+| `synology_container_image_*` | List/get/delete/pull local images | varies |
+| `synology_container_registry_*` | List/search/tags/download registry images | varies |
+| `synology_container_network_*` | List/get/create/delete networks | varies |
+
+All accept `nas_name` / `base_url`.
+
+## Workflow patterns
+
+### Inspect before mutating
+
+For start/stop/restart/delete, first call `synology_container_get(name=...)` or `synology_container_list`. Container names are DSM Container Manager names, not image names.
+
+### Projects are compose projects
+
+Use project tools when the user talks about a compose app, stack, or project folder. `project_create` needs:
+
+```
+name
+share_path
+content  # Docker Compose YAML
+```
+
+`project_update` finds the DSM project by `name` and replaces the compose `content`. List or get the project first if the user is unsure which project they mean.
+
+### Images vs registries
+
+- `synology_container_image_*` works on local images already on the NAS.
+- `synology_container_registry_*` searches/downloads images from the active registry.
+- `synology_container_registry_download` and `synology_container_image_pull` both pull an image by `repository` and optional `tag`.
+
+### Logs and resource usage
+
+Use `synology_container_logs` for "why did it fail?" and `synology_container_resource` for "is it using CPU/memory?". Don't dump long logs raw; summarize errors and recent relevant lines.
+
+## Gotchas
+
+- **Deleting containers/projects/images/networks is destructive.** Inspect first and confirm if the target is not exact.
+- **Names are not paths.** Pass container/project/network names as `name`; only project creation uses `share_path`.
+- **Tags default to `latest`.** Ask or inspect if the user cares about a specific tag.
+- **Network creation is advanced.** Default `driver="bridge"` is fine; only set `subnet`, `gateway`, `ip_range`, or `enable_ipv6` when the user specifies them.
+- **UI-only gaps remain.** Container create/duplicate/reset/settings, interactive terminal, export, global log clear/export, registry settings, and network settings are not exposed.
+
+## Examples
+
+### "Restart watchtower"
+
+```
+synology_container_get(name="watchtower")
+synology_container_restart(name="watchtower")
+```
+
+### "Show logs for plex"
+
+```
+synology_container_logs(name="plex")
+```
+
+Summarize recent errors; don't paste pages of logs.
+
+### "Pull postgres 16"
+
+```
+synology_container_registry_download(repository="postgres", tag="16")
+```
+
+### "Create a compose project"
+
+```
+synology_container_project_create(
+  name="media",
+  share_path="/docker/media",
+  content="services:\n  app:\n    image: caddy:alpine\n"
+)
+```

--- a/src/container/__init__.py
+++ b/src/container/__init__.py
@@ -1,0 +1,3 @@
+from .synology_container import SynologyContainer
+
+__all__ = ["SynologyContainer"]

--- a/src/container/synology_container.py
+++ b/src/container/synology_container.py
@@ -105,7 +105,15 @@ class SynologyContainer:
         if not projects.get("success"):
             return None, projects
 
-        for project in projects.get("data", {}).values():
+        data = projects.get("data", {})
+        if isinstance(data, dict):
+            candidates = list(data.values())
+        elif isinstance(data, list):
+            candidates = data
+        else:
+            candidates = []
+
+        for project in candidates:
             if isinstance(project, dict) and project.get("name") == name:
                 return project["id"], None
 
@@ -224,11 +232,11 @@ class SynologyContainer:
         if enable_service_portal is not None:
             params["enable_service_portal"] = json.dumps(enable_service_portal)
         if service_portal_name is not None:
-            params["service_portal_name"] = service_portal_name
+            params["service_portal_name"] = json.dumps(service_portal_name)
         if service_portal_port is not None:
             params["service_portal_port"] = str(service_portal_port)
         if service_portal_protocol is not None:
-            params["service_portal_protocol"] = service_portal_protocol
+            params["service_portal_protocol"] = json.dumps(service_portal_protocol)
 
         return self._make_request(self.project_api, self.project_version, "update", **params)
 
@@ -386,7 +394,6 @@ class SynologyContainer:
         self,
         name: str,
         since: Optional[str] = None,
-        timestamps: bool = False,
     ) -> Dict[str, Any]:
         """Get Container Manager logs for a container."""
         params = {

--- a/src/container/synology_container.py
+++ b/src/container/synology_container.py
@@ -1,0 +1,430 @@
+"""Synology Container Manager operations."""
+
+import json
+from typing import Any, Dict, Optional
+
+from utils.synology_api import SynologyAPIClient
+
+
+class SynologyContainer:
+    """Manage Container Manager containers on Synology DSM."""
+
+    def __init__(
+        self,
+        base_url: str,
+        session_id: str,
+        verify_ssl: bool = False,
+        syno_token: Optional[str] = None,
+    ):
+        self._api = SynologyAPIClient(base_url, session_id, verify_ssl, syno_token=syno_token)
+        self.container_api = "SYNO.Docker.Container"
+        self.container_version = "1"
+        self.project_api = "SYNO.Docker.Project"
+        self.project_version = "1"
+        self.image_api = "SYNO.Docker.Image"
+        self.image_version = "1"
+        self.registry_api = "SYNO.Docker.Registry"
+        self.registry_version = "1"
+        self.network_api = "SYNO.Docker.Network"
+        self.network_version = "1"
+        self.container_log_api = "SYNO.Docker.Container.Log"
+        self.container_resource_api = "SYNO.Docker.Container.Resource"
+
+    def _make_request(
+        self,
+        api: str,
+        version: str,
+        method: str,
+        **params: Any,
+    ) -> Dict[str, Any]:
+        """Make a request to a Container Manager API."""
+        return self._api.post(api, method, version, params or None)
+
+    def _container_name_request(self, method: str, name: str) -> Dict[str, Any]:
+        """Call a name-based container method."""
+        # DSM expects container names as JSON strings on SYNO.Docker.Container.
+        return self._make_request(
+            self.container_api,
+            self.container_version,
+            method,
+            name=json.dumps(name),
+        )
+
+    def list_containers(
+        self, offset: int = 0, limit: int = -1, container_type: str = "all"
+    ) -> Dict[str, Any]:
+        """List Container Manager containers."""
+        return self._make_request(
+            self.container_api,
+            self.container_version,
+            "list",
+            offset=str(offset),
+            limit=str(limit),
+            type=container_type,
+        )
+
+    def get_container(self, name: str) -> Dict[str, Any]:
+        """Get one Container Manager container by name."""
+        return self._container_name_request("get", name)
+
+    def start_container(self, name: str) -> Dict[str, Any]:
+        """Start a Container Manager container by name."""
+        return self._container_name_request("start", name)
+
+    def stop_container(self, name: str) -> Dict[str, Any]:
+        """Stop a Container Manager container by name."""
+        return self._container_name_request("stop", name)
+
+    def restart_container(self, name: str) -> Dict[str, Any]:
+        """Restart a Container Manager container by name."""
+        return self._container_name_request("restart", name)
+
+    def delete_container(
+        self,
+        name: str,
+        force: bool = False,
+        preserve_profile: bool = True,
+    ) -> Dict[str, Any]:
+        """Delete a Container Manager container by name."""
+        return self._make_request(
+            self.container_api,
+            self.container_version,
+            "delete",
+            name=json.dumps(name),
+            force="true" if force else "false",
+            preserve_profile="true" if preserve_profile else "false",
+        )
+
+    def list_projects(self) -> Dict[str, Any]:
+        """List Container Manager projects."""
+        return self._make_request(self.project_api, self.project_version, "list")
+
+    def _project_id(self, name: str) -> tuple[Optional[str], Optional[Dict[str, Any]]]:
+        """Find DSM's internal project ID for a project name."""
+        projects = self.list_projects()
+        if not projects.get("success"):
+            return None, projects
+
+        for project in projects.get("data", {}).values():
+            if isinstance(project, dict) and project.get("name") == name:
+                return project["id"], None
+
+        return None, {
+            "success": False,
+            "error": {
+                "code": "not_found",
+                "message": f"Container Manager project '{name}' not found",
+            },
+        }
+
+    def _project_id_request(self, method: str, name: str) -> Dict[str, Any]:
+        """Call an ID-based project method by project name."""
+        project_id, error = self._project_id(name)
+        if error:
+            return error
+        return self._make_request(self.project_api, self.project_version, method, id=project_id)
+
+    def _ensure_project_folder(self, share_path: str) -> Dict[str, Any]:
+        """Create the project folder DSM requires before project creation."""
+        folder_path, _, name = share_path.rstrip("/").rpartition("/")
+        if not folder_path or not name:
+            return {
+                "success": False,
+                "error": {
+                    "code": "invalid_path",
+                    "message": "Project share_path must include a parent folder and project name",
+                },
+            }
+
+        return self._make_request(
+            "SYNO.FileStation.CreateFolder",
+            "2",
+            "create",
+            folder_path=folder_path,
+            name=name,
+            force_parent="true",
+        )
+
+    def get_project(self, name: str) -> Dict[str, Any]:
+        """Get a Container Manager project by name."""
+        return self._project_id_request("get", name)
+
+    def start_project(self, name: str) -> Dict[str, Any]:
+        """Start a Container Manager project by name."""
+        return self._project_id_request("start", name)
+
+    def stop_project(self, name: str) -> Dict[str, Any]:
+        """Stop a Container Manager project by name."""
+        return self._project_id_request("stop", name)
+
+    def restart_project(self, name: str) -> Dict[str, Any]:
+        """Restart a Container Manager project by name."""
+        return self._project_id_request("restart", name)
+
+    def build_project(self, name: str) -> Dict[str, Any]:
+        """Build a Container Manager project by name."""
+        return self._project_id_request("build", name)
+
+    def clean_project(self, name: str) -> Dict[str, Any]:
+        """Clean a Container Manager project by name."""
+        return self._project_id_request("clean", name)
+
+    def delete_project(self, name: str) -> Dict[str, Any]:
+        """Delete a Container Manager project by name."""
+        return self._project_id_request("delete", name)
+
+    def create_project(
+        self,
+        name: str,
+        share_path: str,
+        content: str,
+        enable_service_portal: bool = False,
+        service_portal_name: Optional[str] = None,
+        service_portal_port: Optional[int] = None,
+        service_portal_protocol: str = "http",
+    ) -> Dict[str, Any]:
+        """Create a Container Manager project from compose content."""
+        folder = self._ensure_project_folder(share_path)
+        if not folder.get("success"):
+            return folder
+
+        params = {
+            "name": json.dumps(name),
+            "share_path": json.dumps(share_path),
+            "content": json.dumps(""),
+            "enable_service_portal": "true" if enable_service_portal else "false",
+            "service_portal_name": json.dumps(service_portal_name or ""),
+            "service_portal_port": str(service_portal_port or 0),
+            "service_portal_protocol": json.dumps(
+                service_portal_protocol if enable_service_portal else ""
+            ),
+        }
+
+        result = self._make_request(self.project_api, self.project_version, "create", **params)
+        if not result.get("success") or not content:
+            return result
+
+        return self.update_project(name, content)
+
+    def update_project(
+        self,
+        name: str,
+        content: str,
+        enable_service_portal: Optional[bool] = None,
+        service_portal_name: Optional[str] = None,
+        service_portal_port: Optional[int] = None,
+        service_portal_protocol: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Update a Container Manager project's compose content."""
+        project_id, error = self._project_id(name)
+        if error:
+            return error
+
+        params = {"id": project_id, "content": content}
+        if enable_service_portal is not None:
+            params["enable_service_portal"] = json.dumps(enable_service_portal)
+        if service_portal_name is not None:
+            params["service_portal_name"] = service_portal_name
+        if service_portal_port is not None:
+            params["service_portal_port"] = str(service_portal_port)
+        if service_portal_protocol is not None:
+            params["service_portal_protocol"] = service_portal_protocol
+
+        return self._make_request(self.project_api, self.project_version, "update", **params)
+
+    def list_images(
+        self, offset: int = 0, limit: int = -1, show_dsm: bool = False
+    ) -> Dict[str, Any]:
+        """List Container Manager images."""
+        return self._make_request(
+            self.image_api,
+            self.image_version,
+            "list",
+            offset=str(offset),
+            limit=str(limit),
+            show_dsm=json.dumps(show_dsm),
+        )
+
+    def get_image(self, name: str, tag: str = "latest") -> Dict[str, Any]:
+        """Get one Container Manager image."""
+        return self._make_request(self.image_api, self.image_version, "get", image=f"{name}:{tag}")
+
+    def _image_by_name_tag(
+        self, name: str, tag: str
+    ) -> tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
+        """Find a local image object for APIs that require full image payloads."""
+        images = self.list_images(limit=-1)
+        if not images.get("success"):
+            return None, images
+
+        for image in images.get("data", {}).get("images", []):
+            if not isinstance(image, dict):
+                continue
+            if image.get("repository") == name and tag in image.get("tags", []):
+                return image, None
+
+        return None, {
+            "success": False,
+            "error": {
+                "code": "not_found",
+                "message": f"Container Manager image '{name}:{tag}' not found",
+            },
+        }
+
+    def delete_image(self, name: str, tag: str = "latest") -> Dict[str, Any]:
+        """Delete one Container Manager image."""
+        image, error = self._image_by_name_tag(name, tag)
+        if error:
+            return error
+
+        return self._make_request(
+            self.image_api,
+            self.image_version,
+            "delete",
+            images=json.dumps([image]),
+        )
+
+    def pull_image(self, repository: str, tag: str = "latest") -> Dict[str, Any]:
+        """Pull a Container Manager image from a registry."""
+        return self._make_request(
+            self.image_api,
+            self.image_version,
+            "pull_start",
+            repository=repository,
+            tag=tag,
+        )
+
+    def list_registries(self) -> Dict[str, Any]:
+        """List Container Manager registries."""
+        return self._make_request(self.registry_api, self.registry_version, "get")
+
+    def search_registry(self, query: str, offset: int = 0, limit: int = 50) -> Dict[str, Any]:
+        """Search images in Container Manager registries."""
+        return self._make_request(
+            self.registry_api,
+            self.registry_version,
+            "search",
+            q=query,
+            offset=str(offset),
+            limit=str(limit),
+            page_size=str(limit),
+        )
+
+    def list_registry_tags(
+        self, repository: str, offset: int = 0, limit: int = 50
+    ) -> Dict[str, Any]:
+        """List tags for a registry image."""
+        return self._make_request(
+            self.registry_api,
+            "2",
+            "tags",
+            repository=repository,
+            offset=str(offset),
+            limit=str(limit),
+        )
+
+    def list_networks(self) -> Dict[str, Any]:
+        """List Container Manager networks."""
+        return self._make_request(self.network_api, self.network_version, "list")
+
+    def get_network(self, name: str) -> Dict[str, Any]:
+        """Get one Container Manager network by name."""
+        networks = self.list_networks()
+        if not networks.get("success"):
+            return networks
+
+        for network in networks.get("data", {}).get("network", []):
+            if isinstance(network, dict) and network.get("name") == name:
+                return {"success": True, "data": {"network": network}}
+
+        return {
+            "success": False,
+            "error": {
+                "code": "not_found",
+                "message": f"Container Manager network '{name}' not found",
+            },
+        }
+
+    def create_network(
+        self,
+        name: str,
+        driver: str = "bridge",
+        subnet: Optional[str] = None,
+        gateway: Optional[str] = None,
+        ip_range: Optional[str] = None,
+        enable_ipv6: bool = False,
+    ) -> Dict[str, Any]:
+        """Create a Container Manager network."""
+        params = {
+            "name": name,
+            "driver": driver,
+            "enable_ipv6": json.dumps(enable_ipv6),
+        }
+        if subnet is not None:
+            params["subnet"] = subnet
+        if gateway is not None:
+            params["gateway"] = gateway
+        if ip_range is not None:
+            params["iprange"] = ip_range
+
+        return self._make_request(self.network_api, self.network_version, "create", **params)
+
+    def delete_network(self, name: str) -> Dict[str, Any]:
+        """Delete a Container Manager network by name."""
+        network = self.get_network(name)
+        if not network.get("success"):
+            return network
+
+        return self._make_request(
+            self.network_api,
+            self.network_version,
+            "remove",
+            networks=json.dumps([network["data"]["network"]]),
+        )
+
+    def get_container_logs(
+        self,
+        name: str,
+        since: Optional[str] = None,
+        timestamps: bool = False,
+    ) -> Dict[str, Any]:
+        """Get Container Manager logs for a container."""
+        params = {
+            "name": json.dumps(name),
+            "from": json.dumps(since or ""),
+            "to": json.dumps(""),
+            "level": json.dumps(""),
+            "keyword": json.dumps(""),
+            "sort_dir": json.dumps("DESC"),
+            "offset": "0",
+            "limit": "1000",
+        }
+        return self._make_request(self.container_log_api, self.container_version, "get", **params)
+
+    def get_container_resource(self, name: str) -> Dict[str, Any]:
+        """Get real-time resource usage for a container."""
+        result = self._make_request(
+            self.container_resource_api,
+            self.container_version,
+            "get",
+            name=json.dumps(name),
+        )
+        if not result.get("success"):
+            return result
+
+        data = result.get("data", {})
+        resources = data.get("resources")
+        if not isinstance(resources, list):
+            return result
+
+        matches = [resource for resource in resources if resource.get("name") == name]
+        if not matches:
+            return {
+                "success": False,
+                "error": {
+                    "code": "not_found",
+                    "message": f"Container Manager resource '{name}' not found",
+                },
+            }
+
+        return {"success": True, "data": {**data, "resources": matches}}

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -1060,7 +1060,6 @@ class SynologyMCPServer:
             result = container.get_container_logs(
                 arguments["name"],
                 since=arguments.get("since"),
-                timestamps=arguments.get("timestamps", False),
             )
         elif method_name in {
             "project_get",
@@ -1300,10 +1299,6 @@ class SynologyMCPServer:
                 {
                     **name_properties,
                     "since": {"type": "string", "description": "Optional log start time/filter"},
-                    "timestamps": {
-                        "type": "boolean",
-                        "description": "Include log timestamps (default: false)",
-                    },
                 },
                 ["name"],
             ),

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -17,6 +17,7 @@ from mcp.server.models import InitializationOptions
 
 from auth import SynologyAuth
 from config import config
+from container import SynologyContainer
 from downloadstation import SynologyDownloadStation
 from filestation import SynologyFileStation
 from health import SynologyHealth
@@ -42,6 +43,7 @@ class SynologyMCPServer:
         self.filestation_instances: Dict[str, SynologyFileStation] = {}
         self.downloadstation_instances: Dict[str, SynologyDownloadStation] = {}
         self.health_instances: Dict[str, SynologyHealth] = {}
+        self.container_instances: Dict[str, SynologyContainer] = {}
         self.nfs_instances: Dict[str, SynologyNFS] = {}
         self.usermgr_instances: Dict[str, SynologyUserManager] = {}
         self.nas_name_map: Dict[str, str] = {}  # nas_name -> base_url
@@ -94,6 +96,22 @@ class SynologyMCPServer:
             )
 
         return self.health_instances[base_url]
+
+    def _get_container(self, base_url: str) -> SynologyContainer:
+        """Get or create Container Manager instance for a base URL."""
+        if base_url not in self.sessions:
+            raise Exception(f"No active session for {base_url}. Please login first.")
+
+        if base_url not in self.container_instances:
+            session_id = self.sessions[base_url]
+            self.container_instances[base_url] = SynologyContainer(
+                base_url,
+                session_id,
+                verify_ssl=config.verify_ssl,
+                syno_token=self.syno_tokens.get(base_url),
+            )
+
+        return self.container_instances[base_url]
 
     def _get_nfs(self, base_url: str) -> SynologyNFS:
         """Get or create NFS instance for a base URL."""
@@ -148,7 +166,7 @@ class SynologyMCPServer:
             try:
                 nas_cfg = config.get_synology_config(nas_name)
                 base_url = nas_cfg["base_url"]
-                label = nas_name or base_url
+                label = nas_name or "default"
 
                 logger.info(f"Auto-login: {label} ({base_url})...")
 
@@ -171,12 +189,15 @@ class SynologyMCPServer:
                         self.syno_tokens.pop(base_url, None)
                     # Store the name->url mapping for tool resolution
                     self.nas_name_map[label] = base_url
+                    if nas_name is None:
+                        self.nas_name_map[base_url] = base_url
                     logger.info(f"{label}: session {session_id[:8]}...")
 
                     for inst_dict in (
                         self.filestation_instances,
                         self.downloadstation_instances,
                         self.health_instances,
+                        self.container_instances,
                         self.nfs_instances,
                         self.usermgr_instances,
                     ):
@@ -321,6 +342,11 @@ class SynologyMCPServer:
                     return await self._handle_system_log(arguments)
                 elif name == "synology_health_summary":
                     return await self._handle_health_call(arguments, "health_summary")
+                # Container Manager handlers
+                elif name.startswith("synology_container_"):
+                    return await self._handle_container_call(
+                        arguments, name.removeprefix("synology_container_")
+                    )
                 # NFS management handlers
                 elif name == "synology_nfs_status":
                     return await self._handle_nfs_call(arguments, "nfs_status")
@@ -428,6 +454,7 @@ class SynologyMCPServer:
             self.filestation_instances,
             self.downloadstation_instances,
             self.health_instances,
+            self.container_instances,
             self.nfs_instances,
             self.usermgr_instances,
         ):
@@ -474,6 +501,7 @@ class SynologyMCPServer:
                 self.filestation_instances,
                 self.downloadstation_instances,
                 self.health_instances,
+                self.container_instances,
                 self.nfs_instances,
                 self.usermgr_instances,
             ):
@@ -937,6 +965,135 @@ class SynologyMCPServer:
         return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
 
     # ------------------------------------------------------------------
+    # Container Manager handlers
+    # ------------------------------------------------------------------
+
+    async def _handle_container_call(
+        self, arguments: dict, method_name: str
+    ) -> list[types.TextContent]:
+        """Handle Container Manager container operations."""
+        base_url = self._get_base_url(arguments)
+        container = self._get_container(base_url)
+
+        if method_name == "list":
+            result = container.list_containers(
+                offset=arguments.get("offset", 0),
+                limit=arguments.get("limit", -1),
+                container_type=arguments.get("container_type", "all"),
+            )
+        elif method_name == "project_list":
+            result = container.list_projects()
+        elif method_name == "project_create":
+            result = container.create_project(
+                name=arguments["name"],
+                share_path=arguments["share_path"],
+                content=arguments["content"],
+                enable_service_portal=arguments.get("enable_service_portal", False),
+                service_portal_name=arguments.get("service_portal_name"),
+                service_portal_port=arguments.get("service_portal_port"),
+                service_portal_protocol=arguments.get("service_portal_protocol", "http"),
+            )
+        elif method_name == "project_update":
+            result = container.update_project(
+                name=arguments["name"],
+                content=arguments["content"],
+                enable_service_portal=arguments.get("enable_service_portal"),
+                service_portal_name=arguments.get("service_portal_name"),
+                service_portal_port=arguments.get("service_portal_port"),
+                service_portal_protocol=arguments.get("service_portal_protocol"),
+            )
+        elif method_name == "project_delete":
+            result = container.delete_project(arguments["name"])
+        elif method_name == "image_list":
+            result = container.list_images(
+                offset=arguments.get("offset", 0),
+                limit=arguments.get("limit", -1),
+                show_dsm=arguments.get("show_dsm", False),
+            )
+        elif method_name in {"image_get", "image_delete"}:
+            image_method = {
+                "image_get": container.get_image,
+                "image_delete": container.delete_image,
+            }[method_name]
+            result = image_method(arguments["name"], tag=arguments.get("tag", "latest"))
+        elif method_name in {"image_pull", "registry_download"}:
+            result = container.pull_image(
+                arguments["repository"],
+                tag=arguments.get("tag", "latest"),
+            )
+        elif method_name == "registry_list":
+            result = container.list_registries()
+        elif method_name == "registry_search":
+            result = container.search_registry(
+                arguments["query"],
+                offset=arguments.get("offset", 0),
+                limit=arguments.get("limit", 50),
+            )
+        elif method_name == "registry_tags":
+            result = container.list_registry_tags(
+                arguments["repository"],
+                offset=arguments.get("offset", 0),
+                limit=arguments.get("limit", 50),
+            )
+        elif method_name == "network_list":
+            result = container.list_networks()
+        elif method_name == "network_get":
+            result = container.get_network(arguments["name"])
+        elif method_name == "network_create":
+            result = container.create_network(
+                arguments["name"],
+                driver=arguments.get("driver", "bridge"),
+                subnet=arguments.get("subnet"),
+                gateway=arguments.get("gateway"),
+                ip_range=arguments.get("ip_range"),
+                enable_ipv6=arguments.get("enable_ipv6", False),
+            )
+        elif method_name == "network_delete":
+            result = container.delete_network(arguments["name"])
+        elif method_name == "delete":
+            result = container.delete_container(
+                arguments["name"],
+                force=arguments.get("force", False),
+                preserve_profile=arguments.get("preserve_profile", True),
+            )
+        elif method_name == "logs":
+            result = container.get_container_logs(
+                arguments["name"],
+                since=arguments.get("since"),
+                timestamps=arguments.get("timestamps", False),
+            )
+        elif method_name in {
+            "project_get",
+            "project_start",
+            "project_stop",
+            "project_restart",
+            "project_build",
+            "project_clean",
+        }:
+            project_method = {
+                "project_get": container.get_project,
+                "project_start": container.start_project,
+                "project_stop": container.stop_project,
+                "project_restart": container.restart_project,
+                "project_build": container.build_project,
+                "project_clean": container.clean_project,
+            }[method_name]
+            result = project_method(arguments["name"])
+        elif method_name in {"get", "start", "stop", "restart", "resource"}:
+            container_method = {
+                "get": container.get_container,
+                "start": container.start_container,
+                "stop": container.stop_container,
+                "restart": container.restart_container,
+                "resource": container.get_container_resource,
+            }[method_name]
+            result = container_method(arguments["name"])
+        else:
+            raise ValueError(f"Unknown container method: {method_name}")
+
+        return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+
+    # ------------------------------------------------------------------
     # User management handlers
     # ------------------------------------------------------------------
 
@@ -1016,6 +1173,322 @@ class SynologyMCPServer:
         usermgr = self._get_usermgr(base_url)
         result = usermgr.set_user_permissions(arguments["name"], arguments["permissions"])
         return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+
+    def _get_container_tool_definitions(self):
+        """Get Container Manager container tool definitions."""
+        target = {
+            "nas_name": {
+                "type": "string",
+                "description": "NAS identifier from secrets.json (e.g. 'nas1', 'nas2')",
+            },
+            "base_url": {
+                "type": "string",
+                "description": "Synology NAS base URL (alternative to nas_name)",
+            },
+        }
+        name = {"type": "string", "description": "Container name (e.g. 'watchtower')"}
+        project_name = {"type": "string", "description": "Project name (e.g. 'watchtower')"}
+
+        def tool(tool_name: str, description: str, properties: dict, required: list[str]):
+            return types.Tool(
+                name=tool_name,
+                description=description,
+                inputSchema={
+                    "type": "object",
+                    "properties": properties,
+                    "required": required,
+                },
+            )
+
+        name_properties = {**target, "name": name}
+        project_name_properties = {**target, "name": project_name}
+        image_properties = {
+            **target,
+            "name": {"type": "string", "description": "Image repository name (e.g. 'nginx')"},
+            "tag": {"type": "string", "description": "Image tag (default: latest)"},
+        }
+        repository_properties = {
+            **target,
+            "repository": {
+                "type": "string",
+                "description": "Image repository name (e.g. 'nginx')",
+            },
+            "tag": {"type": "string", "description": "Image tag (default: latest)"},
+        }
+        network_properties = {
+            **target,
+            "name": {"type": "string", "description": "Network name"},
+        }
+        project_content_properties = {
+            **project_name_properties,
+            "content": {
+                "type": "string",
+                "description": "Docker Compose YAML content",
+            },
+            "enable_service_portal": {
+                "type": "boolean",
+                "description": "Enable Synology service portal (default: false)",
+            },
+            "service_portal_name": {
+                "type": "string",
+                "description": "Optional service portal name",
+            },
+            "service_portal_port": {
+                "type": "integer",
+                "description": "Optional service portal port",
+            },
+            "service_portal_protocol": {
+                "type": "string",
+                "description": "Service portal protocol (default: http)",
+            },
+        }
+        return [
+            tool(
+                "synology_container_list",
+                "List Container Manager containers",
+                {
+                    **target,
+                    "offset": {"type": "integer", "description": "Pagination offset"},
+                    "limit": {"type": "integer", "description": "Maximum containers to return"},
+                    "container_type": {
+                        "type": "string",
+                        "description": "Container filter (default: all)",
+                    },
+                },
+                [],
+            ),
+            tool(
+                "synology_container_get",
+                "Get a Container Manager container",
+                name_properties,
+                ["name"],
+            ),
+            tool(
+                "synology_container_start",
+                "Start a Container Manager container",
+                name_properties,
+                ["name"],
+            ),
+            tool(
+                "synology_container_stop",
+                "Stop a Container Manager container",
+                name_properties,
+                ["name"],
+            ),
+            tool(
+                "synology_container_restart",
+                "Restart a Container Manager container",
+                name_properties,
+                ["name"],
+            ),
+            tool(
+                "synology_container_delete",
+                "Delete a Container Manager container",
+                {
+                    **name_properties,
+                    "force": {"type": "boolean", "description": "Force deletion (default: false)"},
+                    "preserve_profile": {
+                        "type": "boolean",
+                        "description": "Preserve Synology container profile (default: true)",
+                    },
+                },
+                ["name"],
+            ),
+            tool(
+                "synology_container_logs",
+                "Get Container Manager container logs",
+                {
+                    **name_properties,
+                    "since": {"type": "string", "description": "Optional log start time/filter"},
+                    "timestamps": {
+                        "type": "boolean",
+                        "description": "Include log timestamps (default: false)",
+                    },
+                },
+                ["name"],
+            ),
+            tool(
+                "synology_container_resource",
+                "Get real-time resource usage for a Container Manager container",
+                name_properties,
+                ["name"],
+            ),
+            tool(
+                "synology_container_project_list",
+                "List Container Manager projects",
+                target,
+                [],
+            ),
+            tool(
+                "synology_container_project_get",
+                "Get a Container Manager project",
+                project_name_properties,
+                ["name"],
+            ),
+            tool(
+                "synology_container_project_create",
+                "Create a Container Manager project",
+                {
+                    **project_content_properties,
+                    "share_path": {
+                        "type": "string",
+                        "description": "Project folder path on the NAS",
+                    },
+                },
+                ["name", "share_path", "content"],
+            ),
+            tool(
+                "synology_container_project_update",
+                "Update a Container Manager project",
+                project_content_properties,
+                ["name", "content"],
+            ),
+            tool(
+                "synology_container_project_start",
+                "Start a Container Manager project",
+                project_name_properties,
+                ["name"],
+            ),
+            tool(
+                "synology_container_project_stop",
+                "Stop a Container Manager project",
+                project_name_properties,
+                ["name"],
+            ),
+            tool(
+                "synology_container_project_restart",
+                "Restart a Container Manager project",
+                project_name_properties,
+                ["name"],
+            ),
+            tool(
+                "synology_container_project_build",
+                "Build a Container Manager project",
+                project_name_properties,
+                ["name"],
+            ),
+            tool(
+                "synology_container_project_clean",
+                "Clean a Container Manager project",
+                project_name_properties,
+                ["name"],
+            ),
+            tool(
+                "synology_container_project_delete",
+                "Delete a Container Manager project by name",
+                project_name_properties,
+                ["name"],
+            ),
+            tool(
+                "synology_container_image_list",
+                "List Container Manager images",
+                {
+                    **target,
+                    "offset": {"type": "integer", "description": "Pagination offset"},
+                    "limit": {"type": "integer", "description": "Maximum images to return"},
+                    "show_dsm": {
+                        "type": "boolean",
+                        "description": "Include DSM images (default: false)",
+                    },
+                },
+                [],
+            ),
+            tool(
+                "synology_container_image_get",
+                "Get a Container Manager image",
+                image_properties,
+                ["name"],
+            ),
+            tool(
+                "synology_container_image_delete",
+                "Delete a Container Manager image",
+                image_properties,
+                ["name"],
+            ),
+            tool(
+                "synology_container_image_pull",
+                "Pull a Container Manager image",
+                repository_properties,
+                ["repository"],
+            ),
+            tool(
+                "synology_container_registry_list",
+                "List Container Manager registries",
+                target,
+                [],
+            ),
+            tool(
+                "synology_container_registry_search",
+                "Search Container Manager registries",
+                {
+                    **target,
+                    "query": {"type": "string", "description": "Image search query"},
+                    "offset": {"type": "integer", "description": "Pagination offset"},
+                    "limit": {"type": "integer", "description": "Maximum results to return"},
+                },
+                ["query"],
+            ),
+            tool(
+                "synology_container_registry_tags",
+                "List tags for a registry image",
+                {
+                    **target,
+                    "repository": {
+                        "type": "string",
+                        "description": "Image repository name (e.g. 'nginx')",
+                    },
+                    "offset": {"type": "integer", "description": "Pagination offset"},
+                    "limit": {"type": "integer", "description": "Maximum tags to return"},
+                },
+                ["repository"],
+            ),
+            tool(
+                "synology_container_registry_download",
+                "Download a registry image",
+                repository_properties,
+                ["repository"],
+            ),
+            tool(
+                "synology_container_network_list",
+                "List Container Manager networks",
+                target,
+                [],
+            ),
+            tool(
+                "synology_container_network_get",
+                "Get a Container Manager network",
+                network_properties,
+                ["name"],
+            ),
+            tool(
+                "synology_container_network_create",
+                "Create a Container Manager network",
+                {
+                    **network_properties,
+                    "driver": {
+                        "type": "string",
+                        "description": "Network driver (default: bridge)",
+                    },
+                    "subnet": {
+                        "type": "string",
+                        "description": "Subnet CIDR (e.g. 172.28.0.0/16)",
+                    },
+                    "gateway": {"type": "string", "description": "Gateway IP"},
+                    "ip_range": {"type": "string", "description": "Allocatable IP range CIDR"},
+                    "enable_ipv6": {
+                        "type": "boolean",
+                        "description": "Enable IPv6 (default: false)",
+                    },
+                },
+                ["name"],
+            ),
+            tool(
+                "synology_container_network_delete",
+                "Delete a Container Manager network",
+                network_properties,
+                ["name"],
+            ),
+        ]
 
     def _get_tool_definitions(self):
         """Get tool definitions shared between MCP handler and bridge."""
@@ -1678,6 +2151,10 @@ class SynologyMCPServer:
                 },
             ),
             # ============================================================
+            # Container Manager Tools
+            # ============================================================
+            *self._get_container_tool_definitions(),
+            # ============================================================
             # NFS Management Tools
             # ============================================================
             types.Tool(
@@ -2165,6 +2642,10 @@ class SynologyMCPServer:
             }
 
             handler = dispatch.get(name)
+            if handler is None and name.startswith("synology_container_"):
+                return await self._handle_container_call(
+                    arguments, name.removeprefix("synology_container_")
+                )
             if handler is None:
                 raise ValueError(f"Unknown tool: {name}")
             return await handler(arguments)
@@ -2256,6 +2737,7 @@ class SynologyMCPServer:
                     self.filestation_instances,
                     self.downloadstation_instances,
                     self.health_instances,
+                    self.container_instances,
                     self.nfs_instances,
                     self.usermgr_instances,
                 ):

--- a/tests/test_container_manager.py
+++ b/tests/test_container_manager.py
@@ -1,0 +1,512 @@
+"""Container Manager module tests."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _container():
+    from container.synology_container import SynologyContainer
+
+    return SynologyContainer(
+        "https://nas.example.com:5001",
+        "sid_xyz",
+        verify_ssl=False,
+        syno_token="tok_abc",
+    )
+
+
+def _successful_response(data=None):
+    fake_response = MagicMock()
+    fake_response.json.return_value = {"data": data or {}, "success": True}
+    fake_response.raise_for_status = MagicMock()
+    return fake_response
+
+
+@pytest.mark.parametrize(
+    ("method_name", "api_method"),
+    [
+        ("get_container", "get"),
+        ("start_container", "start"),
+        ("stop_container", "stop"),
+        ("restart_container", "restart"),
+        ("get_container_resource", "get"),
+    ],
+)
+def test_container_name_methods_quote_name_for_dsm(method_name, api_method):
+    """Name-based Container Manager methods JSON-quote the container name."""
+    container = _container()
+
+    with patch(
+        "utils.synology_api.requests.post",
+        return_value=_successful_response(),
+    ) as post:
+        result = getattr(container, method_name)("watchtower")
+
+    assert result == {"data": {}, "success": True}
+
+    sent_data = post.call_args.kwargs["data"]
+    sent_headers = post.call_args.kwargs["headers"]
+
+    assert sent_headers is not None
+    assert sent_headers.get("X-SYNO-TOKEN") == "tok_abc"
+
+    expected_api = (
+        "SYNO.Docker.Container.Resource"
+        if method_name == "get_container_resource"
+        else "SYNO.Docker.Container"
+    )
+
+    assert sent_data["api"] == expected_api
+    assert sent_data["method"] == api_method
+    assert sent_data["version"] == "1"
+    assert sent_data["_sid"] == "sid_xyz"
+    assert sent_data["name"] == '"watchtower"'
+
+
+def test_container_list_wire_format_matches_dsm():
+    """List sends Container Manager pagination and type filters."""
+    container = _container()
+
+    with patch(
+        "utils.synology_api.requests.post",
+        return_value=_successful_response({"containers": []}),
+    ) as post:
+        result = container.list_containers(offset=5, limit=10, container_type="running")
+
+    assert result == {"data": {"containers": []}, "success": True}
+
+    sent_data = post.call_args.kwargs["data"]
+    assert sent_data["api"] == "SYNO.Docker.Container"
+    assert sent_data["method"] == "list"
+    assert sent_data["version"] == "1"
+    assert sent_data["_sid"] == "sid_xyz"
+    assert sent_data["offset"] == "5"
+    assert sent_data["limit"] == "10"
+    assert sent_data["type"] == "running"
+
+
+def test_container_resource_filters_requested_container():
+    """Resource lookup returns only the requested container's resource entry."""
+    container = _container()
+
+    with patch(
+        "utils.synology_api.requests.post",
+        return_value=_successful_response(
+            {
+                "resources": [
+                    {"name": "watchtower", "cpu": 1.0},
+                    {"name": "postgres", "cpu": 2.0},
+                ]
+            }
+        ),
+    ):
+        result = container.get_container_resource("watchtower")
+
+    assert result == {
+        "data": {"resources": [{"name": "watchtower", "cpu": 1.0}]},
+        "success": True,
+    }
+
+
+def test_container_delete_wire_format_matches_dsm():
+    """Delete sends quoted name and force/preserve_profile flags."""
+    container = _container()
+
+    with patch(
+        "utils.synology_api.requests.post",
+        return_value=_successful_response(),
+    ) as post:
+        container.delete_container("old-container", force=True, preserve_profile=False)
+
+    sent_data = post.call_args.kwargs["data"]
+    assert sent_data["api"] == "SYNO.Docker.Container"
+    assert sent_data["method"] == "delete"
+    assert sent_data["name"] == '"old-container"'
+    assert sent_data["force"] == "true"
+    assert sent_data["preserve_profile"] == "false"
+
+
+@pytest.mark.parametrize(
+    ("method_name", "api_method"),
+    [
+        ("get_project", "get"),
+        ("start_project", "start"),
+        ("stop_project", "stop"),
+        ("restart_project", "restart"),
+        ("build_project", "build"),
+        ("clean_project", "clean"),
+        ("delete_project", "delete"),
+    ],
+)
+def test_project_name_methods_find_project_id_before_calling_dsm(method_name, api_method):
+    """Project methods are name-based for MCP callers and ID-based for DSM."""
+    container = _container()
+
+    with patch(
+        "utils.synology_api.requests.post",
+        side_effect=[
+            _successful_response(
+                {
+                    "abc-123": {
+                        "id": "abc-123",
+                        "name": "watchtower",
+                        "path": "/volume1/docker/appdata/watchtower",
+                    }
+                }
+            ),
+            _successful_response(),
+        ],
+    ) as post:
+        result = getattr(container, method_name)("watchtower")
+
+    assert result == {"data": {}, "success": True}
+
+    list_data = post.call_args_list[0].kwargs["data"]
+    assert list_data["api"] == "SYNO.Docker.Project"
+    assert list_data["method"] == "list"
+
+    action_data = post.call_args_list[1].kwargs["data"]
+    assert action_data["api"] == "SYNO.Docker.Project"
+    assert action_data["method"] == api_method
+    assert action_data["id"] == "abc-123"
+
+
+def test_project_create_wire_format_matches_dsm():
+    """Project creation follows DSM's create-empty-then-update flow."""
+    container = _container()
+
+    with patch(
+        "utils.synology_api.requests.post",
+        side_effect=[
+            _successful_response({"folders": [{"path": "/docker/media", "name": "media"}]}),
+            _successful_response(),
+            _successful_response({"abc-123": {"id": "abc-123", "name": "media"}}),
+            _successful_response(),
+        ],
+    ) as post:
+        result = container.create_project(
+            name="media",
+            share_path="/docker/media",
+            content="services:\n  app:\n    image: caddy:alpine\n",
+            enable_service_portal=True,
+            service_portal_name="media",
+            service_portal_port=8080,
+            service_portal_protocol="https",
+        )
+
+    assert result == {"data": {}, "success": True}
+
+    mkdir_data = post.call_args_list[0].kwargs["data"]
+    assert mkdir_data["api"] == "SYNO.FileStation.CreateFolder"
+    assert mkdir_data["method"] == "create"
+    assert mkdir_data["folder_path"] == "/docker"
+    assert mkdir_data["name"] == "media"
+    assert mkdir_data["force_parent"] == "true"
+
+    sent_data = post.call_args_list[1].kwargs["data"]
+    assert sent_data["api"] == "SYNO.Docker.Project"
+    assert sent_data["method"] == "create"
+    assert sent_data["version"] == "1"
+    assert sent_data["name"] == '"media"'
+    assert sent_data["share_path"] == '"/docker/media"'
+    assert sent_data["content"] == '""'
+    assert sent_data["enable_service_portal"] == "true"
+    assert sent_data["service_portal_name"] == '"media"'
+    assert sent_data["service_portal_port"] == "8080"
+    assert sent_data["service_portal_protocol"] == '"https"'
+
+    list_data = post.call_args_list[2].kwargs["data"]
+    assert list_data["method"] == "list"
+
+    update_data = post.call_args_list[3].kwargs["data"]
+    assert update_data["method"] == "update"
+    assert update_data["id"] == "abc-123"
+    assert update_data["content"] == "services:\n  app:\n    image: caddy:alpine\n"
+
+
+def test_project_update_finds_project_id_before_updating():
+    """Project updates find DSM's internal ID before posting compose content."""
+    container = _container()
+
+    with patch(
+        "utils.synology_api.requests.post",
+        side_effect=[
+            _successful_response({"abc-123": {"id": "abc-123", "name": "media"}}),
+            _successful_response(),
+        ],
+    ) as post:
+        result = container.update_project(
+            name="media",
+            content="services:\n  app:\n    image: caddy:latest\n",
+            enable_service_portal=False,
+        )
+
+    assert result == {"data": {}, "success": True}
+
+    update_data = post.call_args_list[1].kwargs["data"]
+    assert update_data["api"] == "SYNO.Docker.Project"
+    assert update_data["method"] == "update"
+    assert update_data["id"] == "abc-123"
+    assert update_data["content"] == "services:\n  app:\n    image: caddy:latest\n"
+    assert update_data["enable_service_portal"] == "false"
+
+
+def test_image_methods_wire_format_matches_dsm():
+    """Image tools expose local image list/get/delete and pull."""
+    container = _container()
+
+    with patch(
+        "utils.synology_api.requests.post",
+        side_effect=[
+            _successful_response({"images": []}),
+            _successful_response(),
+            _successful_response(
+                {
+                    "images": [
+                        {
+                            "id": "sha256:caddy",
+                            "repository": "caddy",
+                            "tags": ["alpine"],
+                        }
+                    ]
+                }
+            ),
+            _successful_response(),
+            _successful_response({"task_id": "pull-1"}),
+        ],
+    ) as post:
+        assert container.list_images(offset=2, limit=5) == {
+            "data": {"images": []},
+            "success": True,
+        }
+        container.get_image("caddy", tag="alpine")
+        container.delete_image("caddy", tag="alpine")
+        container.pull_image("caddy", tag="alpine")
+
+    list_data = post.call_args_list[0].kwargs["data"]
+    assert list_data["api"] == "SYNO.Docker.Image"
+    assert list_data["method"] == "list"
+    assert list_data["limit"] == "5"
+    assert list_data["offset"] == "2"
+
+    get_data = post.call_args_list[1].kwargs["data"]
+    assert get_data["method"] == "get"
+    assert get_data["image"] == "caddy:alpine"
+    assert "name" not in get_data
+    assert "tag" not in get_data
+
+    delete_lookup_data = post.call_args_list[2].kwargs["data"]
+    assert delete_lookup_data["method"] == "list"
+    assert delete_lookup_data["limit"] == "-1"
+
+    delete_data = post.call_args_list[3].kwargs["data"]
+    assert delete_data["method"] == "delete"
+    assert json.loads(delete_data["images"]) == [
+        {"id": "sha256:caddy", "repository": "caddy", "tags": ["alpine"]}
+    ]
+    assert "name" not in delete_data
+    assert "tag" not in delete_data
+
+    pull_data = post.call_args_list[4].kwargs["data"]
+    assert pull_data["method"] == "pull_start"
+    assert pull_data["repository"] == "caddy"
+    assert pull_data["tag"] == "alpine"
+
+
+def test_registry_methods_wire_format_matches_dsm():
+    """Registry tools expose registry list, search, tags, and download."""
+    container = _container()
+
+    with patch(
+        "utils.synology_api.requests.post",
+        side_effect=[
+            _successful_response({"registries": []}),
+            _successful_response({"data": []}),
+            _successful_response({"tags": ["latest"]}),
+            _successful_response({"task_id": "pull-1"}),
+        ],
+    ) as post:
+        container.list_registries()
+        container.search_registry("postgres", offset=10, limit=25)
+        container.list_registry_tags("postgres", offset=5, limit=10)
+        container.pull_image("postgres", tag="16")
+
+    assert post.call_args_list[0].kwargs["data"]["api"] == "SYNO.Docker.Registry"
+    assert post.call_args_list[0].kwargs["data"]["method"] == "get"
+
+    search_data = post.call_args_list[1].kwargs["data"]
+    assert search_data["api"] == "SYNO.Docker.Registry"
+    assert search_data["method"] == "search"
+    assert search_data["q"] == "postgres"
+    assert search_data["offset"] == "10"
+    assert search_data["limit"] == "25"
+    assert search_data["page_size"] == "25"
+
+    tags_data = post.call_args_list[2].kwargs["data"]
+    assert tags_data["method"] == "tags"
+    assert tags_data["version"] == "2"
+    assert tags_data["repository"] == "postgres"
+    assert "name" not in tags_data
+    assert tags_data["offset"] == "5"
+    assert tags_data["limit"] == "10"
+
+    download_data = post.call_args_list[3].kwargs["data"]
+    assert download_data["api"] == "SYNO.Docker.Image"
+    assert download_data["method"] == "pull_start"
+    assert download_data["repository"] == "postgres"
+    assert download_data["tag"] == "16"
+
+
+def test_network_methods_wire_format_matches_dsm():
+    """Network tools expose list/get/create/delete by name."""
+    container = _container()
+
+    with patch(
+        "utils.synology_api.requests.post",
+        side_effect=[
+            _successful_response(
+                {"network": [{"id": "net-1", "name": "app_net", "driver": "bridge"}]}
+            ),
+            _successful_response(
+                {"network": [{"id": "net-1", "name": "app_net", "driver": "bridge"}]}
+            ),
+            _successful_response(),
+            _successful_response(
+                {"network": [{"id": "net-1", "name": "app_net", "driver": "bridge"}]}
+            ),
+            _successful_response(),
+        ],
+    ) as post:
+        container.list_networks()
+        assert container.get_network("app_net") == {
+            "data": {"network": {"id": "net-1", "name": "app_net", "driver": "bridge"}},
+            "success": True,
+        }
+        container.create_network(
+            "app_net",
+            subnet="172.28.0.0/16",
+            gateway="172.28.0.1",
+            ip_range="172.28.5.0/24",
+            enable_ipv6=True,
+        )
+        container.delete_network("app_net")
+
+    assert post.call_args_list[0].kwargs["data"]["api"] == "SYNO.Docker.Network"
+    assert post.call_args_list[0].kwargs["data"]["method"] == "list"
+
+    create_data = post.call_args_list[2].kwargs["data"]
+    assert create_data["method"] == "create"
+    assert create_data["name"] == "app_net"
+    assert create_data["driver"] == "bridge"
+    assert create_data["subnet"] == "172.28.0.0/16"
+    assert create_data["gateway"] == "172.28.0.1"
+    assert create_data["iprange"] == "172.28.5.0/24"
+    assert create_data["enable_ipv6"] == "true"
+
+    delete_lookup_data = post.call_args_list[3].kwargs["data"]
+    assert delete_lookup_data["method"] == "list"
+
+    delete_data = post.call_args_list[4].kwargs["data"]
+    assert delete_data["method"] == "remove"
+    assert json.loads(delete_data["networks"]) == [
+        {"id": "net-1", "name": "app_net", "driver": "bridge"}
+    ]
+
+
+def test_container_logs_wire_format_matches_dsm():
+    """Logs use the same filter payload as DSM's Container Manager UI."""
+    container = _container()
+
+    with patch(
+        "utils.synology_api.requests.post",
+        return_value=_successful_response({"logs": []}),
+    ) as post:
+        container.get_container_logs("watchtower", since="2026-06-13T00:00:00", timestamps=True)
+
+    sent_data = post.call_args.kwargs["data"]
+    assert sent_data["api"] == "SYNO.Docker.Container.Log"
+    assert sent_data["method"] == "get"
+    assert sent_data["version"] == "1"
+    assert sent_data["name"] == '"watchtower"'
+    assert sent_data["from"] == '"2026-06-13T00:00:00"'
+    assert sent_data["to"] == '""'
+    assert sent_data["level"] == '""'
+    assert sent_data["keyword"] == '""'
+    assert sent_data["sort_dir"] == '"DESC"'
+    assert sent_data["offset"] == "0"
+    assert sent_data["limit"] == "1000"
+    assert "timestamps" not in sent_data
+
+
+def test_container_tools_are_registered():
+    """MCP exposes the container operations."""
+    from mcp_server import SynologyMCPServer
+
+    server = SynologyMCPServer()
+    names = {tool.name for tool in server._get_tool_definitions()}
+
+    assert {
+        "synology_container_list",
+        "synology_container_get",
+        "synology_container_start",
+        "synology_container_stop",
+        "synology_container_restart",
+        "synology_container_delete",
+        "synology_container_logs",
+        "synology_container_resource",
+        "synology_container_project_list",
+        "synology_container_project_get",
+        "synology_container_project_create",
+        "synology_container_project_update",
+        "synology_container_project_start",
+        "synology_container_project_stop",
+        "synology_container_project_restart",
+        "synology_container_project_build",
+        "synology_container_project_clean",
+        "synology_container_project_delete",
+        "synology_container_image_list",
+        "synology_container_image_get",
+        "synology_container_image_delete",
+        "synology_container_image_pull",
+        "synology_container_registry_list",
+        "synology_container_registry_search",
+        "synology_container_registry_tags",
+        "synology_container_registry_download",
+        "synology_container_network_list",
+        "synology_container_network_get",
+        "synology_container_network_create",
+        "synology_container_network_delete",
+    }.issubset(names)
+
+    assert "synology_container_api_call" not in names
+
+
+@pytest.mark.asyncio
+async def test_legacy_single_nas_auto_login_registers_default_name():
+    """Legacy single-NAS config should match synology_list_nas' default name."""
+    from mcp_server import SynologyMCPServer
+
+    server = SynologyMCPServer()
+    auth = MagicMock()
+    auth.login.return_value = {"success": True, "data": {"sid": "sid_xyz", "synotoken": "tok_abc"}}
+
+    with (
+        patch("mcp_server.SynologyAuth", return_value=auth),
+        patch("mcp_server.config") as fake_config,
+    ):
+        fake_config.auto_login = True
+        fake_config.has_synology_credentials.return_value = True
+        fake_config.get_nas_names.return_value = []
+        fake_config.get_synology_config.return_value = {
+            "base_url": "http://nas.example.com:5000/",
+            "username": "user",
+            "password": "pass",
+        }
+        fake_config.verify_ssl = False
+        fake_config.debug = False
+
+        await server._auto_login_if_configured()
+
+    assert server.nas_name_map["default"] == "http://nas.example.com:5000/"

--- a/tests/test_container_manager.py
+++ b/tests/test_container_manager.py
@@ -253,6 +253,63 @@ def test_project_update_finds_project_id_before_updating():
     assert update_data["enable_service_portal"] == "false"
 
 
+def test_project_update_quotes_service_portal_params_like_create():
+    """Portal name/protocol must be JSON-quoted on update, matching create."""
+    container = _container()
+
+    with patch(
+        "utils.synology_api.requests.post",
+        side_effect=[
+            _successful_response({"abc-123": {"id": "abc-123", "name": "media"}}),
+            _successful_response(),
+        ],
+    ) as post:
+        container.update_project(
+            name="media",
+            content="services:\n  app:\n    image: caddy:latest\n",
+            enable_service_portal=True,
+            service_portal_name="media",
+            service_portal_port=8080,
+            service_portal_protocol="https",
+        )
+
+    update_data = post.call_args_list[1].kwargs["data"]
+    assert update_data["enable_service_portal"] == "true"
+    assert update_data["service_portal_name"] == '"media"'
+    assert update_data["service_portal_port"] == "8080"
+    assert update_data["service_portal_protocol"] == '"https"'
+
+
+def _response_with_data(data):
+    """Build a success response whose `data` is exactly `data` (no falsy coercion)."""
+    fake_response = MagicMock()
+    fake_response.json.return_value = {"data": data, "success": True}
+    fake_response.raise_for_status = MagicMock()
+    return fake_response
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        [{"id": "x", "name": "other"}],  # DSM returns a list
+        None,  # DSM returns null
+        "unexpected",  # DSM returns something else entirely
+    ],
+)
+def test_project_id_lookup_tolerates_non_dict_data(data):
+    """A list/None/other project payload yields a structured not-found, not a crash."""
+    container = _container()
+
+    with patch(
+        "utils.synology_api.requests.post",
+        return_value=_response_with_data(data),
+    ):
+        result = container.get_project("missing")
+
+    assert result["success"] is False
+    assert result["error"]["code"] == "not_found"
+
+
 def test_image_methods_wire_format_matches_dsm():
     """Image tools expose local image list/get/delete and pull."""
     container = _container()
@@ -423,7 +480,7 @@ def test_container_logs_wire_format_matches_dsm():
         "utils.synology_api.requests.post",
         return_value=_successful_response({"logs": []}),
     ) as post:
-        container.get_container_logs("watchtower", since="2026-06-13T00:00:00", timestamps=True)
+        container.get_container_logs("watchtower", since="2026-06-13T00:00:00")
 
     sent_data = post.call_args.kwargs["data"]
     assert sent_data["api"] == "SYNO.Docker.Container.Log"

--- a/tests/test_download_station.py
+++ b/tests/test_download_station.py
@@ -41,13 +41,13 @@ class TestRealDownloadStation:
 
             # Format size
             if size > 1024 * 1024 * 1024:
-                size_str = f"{size/(1024*1024*1024):.1f} GB"
+                size_str = f"{size / (1024 * 1024 * 1024):.1f} GB"
             elif size > 1024 * 1024:
-                size_str = f"{size/(1024*1024):.1f} MB"
+                size_str = f"{size / (1024 * 1024):.1f} MB"
             else:
                 size_str = f"{size:,} B"
 
-            print(f"  {i+1}. {title[:50]}... [{status}] ({size_str})")
+            print(f"  {i + 1}. {title[:50]}... [{status}] ({size_str})")
 
     def test_download_statistics(self, download_station):
         """Test getting download statistics."""
@@ -61,9 +61,9 @@ class TestRealDownloadStation:
         # Format speeds
         def format_speed(speed):
             if speed > 1024 * 1024:
-                return f"{speed/(1024*1024):.1f} MB/s"
+                return f"{speed / (1024 * 1024):.1f} MB/s"
             elif speed > 1024:
-                return f"{speed/1024:.1f} KB/s"
+                return f"{speed / 1024:.1f} KB/s"
             else:
                 return f"{speed} B/s"
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,7 +1,8 @@
 """Health monitoring module tests."""
 
-import pytest
 from unittest.mock import patch
+
+import pytest
 
 
 @pytest.mark.real_nas
@@ -204,6 +205,7 @@ class TestSystemInfoFallback:
 
     def _make_health(self):
         from health.synology_health import SynologyHealth
+
         return SynologyHealth("http://nas:5000", "fake-sid", verify_ssl=False)
 
     def test_primary_success(self):
@@ -218,7 +220,10 @@ class TestSystemInfoFallback:
     def test_fallback_uses_version_2(self):
         """Falls back to SYNO.DSM.Info v2 when SYNO.Core.System fails."""
         health = self._make_health()
-        dsm_info = {"success": True, "data": {"model": "DS1621+", "version_string": "DSM 7.3.2-86009"}}
+        dsm_info = {
+            "success": True,
+            "data": {"model": "DS1621+", "version_string": "DSM 7.3.2-86009"},
+        }
 
         def side_effect(api, method, version=1, extra_params=None):
             if api == "SYNO.Core.System":
@@ -234,7 +239,9 @@ class TestSystemInfoFallback:
     def test_both_fail(self):
         """Returns the fallback error when both APIs fail."""
         health = self._make_health()
-        with patch.object(health._api, "get", return_value={"success": False, "error": {"code": 104}}):
+        with patch.object(
+            health._api, "get", return_value={"success": False, "error": {"code": 104}}
+        ):
             result = health.system_info()
         assert not result.get("success")
 


### PR DESCRIPTION
<!--
PR title guidance:
Use a concise, imperative title that summarizes the change.

If this project uses Conventional Commits, prefer:
<type>(optional-scope): summary

Examples:
feat(auth): add password reset flow
fix(api): handle empty response bodies
docs(readme): clarify setup steps
-->

## Summary

<!--
Describe what changed, why it matters, and the scope of this PR.
Bullets are encouraged.
-->

- Add Synology DSM Container Manager support to the MCP server.
- Add Container Manager tools for containers, compose projects, images, registries, and networks.
- Wire Container Manager session caching and tool routing into the existing MCP server patterns.
- Update README and Synology NAS skill docs with Container Manager usage, gotchas, examples, and eval coverage.

## Linked issues

<!--
Link related issues here.

Use closing keywords only when merging this PR should close the issue:
Fixes #123
Closes #123

Otherwise use:
Related to #123
-->

N/A

## Type of change

<!--
Check all that apply. Keep these aligned with repository labels and release-note categories.
-->

- [ ] Bug fix
- [x] Feature
- [x] Documentation
- [ ] Refactor / maintenance
- [x] Tests
- [ ] CI / build / dependencies
- [ ] Performance
- [ ] Security
- [ ] Breaking change

## Reviewer guidance

<!--
Help reviewers focus their attention.

Consider mentioning:
- Where reviewers should start
- Risky or complex files
- Whether this needs architecture review or a quick sanity check
- Any generated files or non-obvious changes
-->

Start with `src/container/synology_container.py`, then review MCP wiring in `src/mcp_server.py` and tests in `tests/test_container_manager.py`.

Destructive operations are intentionally explicit: delete tools require exact names, and docs tell agents to inspect before mutating.

## Test plan

<!--
Describe how this was tested.

Include automated checks, manual verification, or explain why tests are not applicable.
Keep related test changes in the same PR when practical.
-->

- [x] Automated tests added or updated
- [x] Existing automated tests pass
- [x] Manual verification completed
- [ ] Tests are not applicable

Details:

```bash
uv run pytest -q tests/test_container_manager.py tests/test_health.py -m 'not real_nas'
uvx ruff check src/container/__init__.py src/container/synology_container.py src/mcp_server.py tests/test_container_manager.py tests/test_download_station.py tests/test_health.py
```

Already run locally:

- `uv run pytest -q tests/test_container_manager.py tests/test_health.py -m 'not real_nas'` passed: `28 passed, 10 deselected`
- `uvx ruff check ...` passed

Skipped:

- `uv run pytest -q tests/test_download_station.py -m 'not real_nas'` hung in live NAS fixtures; that file only contains `real_nas` integration tests.

Manual smoke test:

Ask an MCP client connected to this server to install AdGuard Home from `https://hub.docker.com/r/adguard/adguardhome`.

Expected path:

1. Pull `adguard/adguardhome:latest`.
2. Create compose project `adguardhome` under `/docker/adguardhome`.
3. Start the project.
4. Confirm the project/container is running.
5. Inspect logs if startup fails.

Expected result: AdGuard Home container/project exists and starts; setup UI should be reachable on port `3000` after DSM finishes creating the project.

## Screenshots or evidence

<!--
Add screenshots, CLI output, logs, benchmark results, migration dry-runs,
or before/after examples when helpful.

Use N/A if not applicable.
-->

N/A

## Release and changelog impact

<!--
Describe whether this change is user-facing and whether it needs release notes.
-->

- [x] User-facing change
- [ ] Changelog entry needed
- [ ] Breaking change
- [ ] Should be excluded from generated release notes
- [ ] No release or changelog impact

Details:

Adds user-facing MCP tools for Synology DSM Container Manager. Release notes may mention new Container Manager support if this project keeps user-facing release notes outside the changelog checkbox flow.

## Deployment, rollback, and risk

<!--
Use this section when applicable.

Consider:
- Feature flags
- Data migrations
- Rollout order
- Rollback steps
- Operational risks
-->

N/A

## Security and privacy

<!--
Do not include secrets, credentials, private keys, sensitive customer data,
unsafe logs, or private vulnerability details in this PR.

Call out changes involving permissions, dependencies, authentication,
authorization, logging, or data handling.
-->

- [x] This PR does not include secrets, credentials, private keys, or sensitive data
- [x] Security/privacy impact has been considered
- [x] Permission, dependency, auth, or data-handling changes have been reviewed
- [ ] Not applicable

Details:

Container Manager tools can mutate NAS resources. Delete and other destructive operations require explicit names, and docs instruct agents to inspect resources before mutating.

## Author checklist

<!--
Complete before requesting review.
-->

- [x] I performed a self-review
- [x] The PR is focused on one purpose
- [x] I split unrelated behavior, refactors, migrations, or generated updates where practical
- [x] I added or updated tests, or explained why tests are not applicable
- [x] I updated documentation where needed
- [x] I kept CI usage reasonable and avoided unnecessary expensive checks
- [x] I confirmed this PR does not expose secrets or sensitive data
