### PR TITLE
fix(logout): evict all service instance caches on logout

### DIFF
--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -537,13 +537,18 @@ class SynologyMCPServer:
 
         # Handle the result and provide detailed feedback
         if result.get("success"):
-            # Remove session and FileStation/DownloadStation instances on successful logout
+            # Remove session and all cached service instances on successful logout
             del self.sessions[base_url]
             self.syno_tokens.pop(base_url, None)
-            if base_url in self.filestation_instances:
-                del self.filestation_instances[base_url]
-            if base_url in self.downloadstation_instances:
-                del self.downloadstation_instances[base_url]
+            for inst_dict in (
+                self.filestation_instances,
+                self.downloadstation_instances,
+                self.health_instances,
+                self.container_instances,
+                self.nfs_instances,
+                self.usermgr_instances,
+            ):
+                inst_dict.pop(base_url, None)
 
             return [
                 types.TextContent(
@@ -562,10 +567,15 @@ class SynologyMCPServer:
                 # Still clean up local session data
                 del self.sessions[base_url]
                 self.syno_tokens.pop(base_url, None)
-                if base_url in self.filestation_instances:
-                    del self.filestation_instances[base_url]
-                if base_url in self.downloadstation_instances:
-                    del self.downloadstation_instances[base_url]
+                for inst_dict in (
+                    self.filestation_instances,
+                    self.downloadstation_instances,
+                    self.health_instances,
+                    self.container_instances,
+                    self.nfs_instances,
+                    self.usermgr_instances,
+                ):
+                    inst_dict.pop(base_url, None)
 
                 return [
                     types.TextContent(

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -193,14 +193,7 @@ class SynologyMCPServer:
                         self.nas_name_map[base_url] = base_url
                     logger.info(f"{label}: session {session_id[:8]}...")
 
-                    for inst_dict in (
-                        self.filestation_instances,
-                        self.downloadstation_instances,
-                        self.health_instances,
-                        self.container_instances,
-                        self.nfs_instances,
-                        self.usermgr_instances,
-                    ):
+                    for inst_dict in self._service_instance_dicts():
                         inst_dict.pop(base_url, None)
                     success_count += 1
                 else:
@@ -386,6 +379,21 @@ class SynologyMCPServer:
             except Exception as e:
                 return [types.TextContent(type="text", text=f"Error executing {name}: {str(e)}")]
 
+    def _service_instance_dicts(self):
+        """Canonical set of per-domain instance caches keyed by base_url.
+
+        Returned as one tuple so session login/relogin/logout/cleanup all evict
+        the same set; adding a new service means updating this one place.
+        """
+        return (
+            self.filestation_instances,
+            self.downloadstation_instances,
+            self.health_instances,
+            self.container_instances,
+            self.nfs_instances,
+            self.usermgr_instances,
+        )
+
     def _get_base_url(self, arguments: dict) -> str:
         """Get base URL from arguments or config.
 
@@ -450,14 +458,7 @@ class SynologyMCPServer:
         else:
             self.syno_tokens.pop(base_url, None)
         # Drop cached service instances so they rebuild with the refreshed session.
-        for inst_dict in (
-            self.filestation_instances,
-            self.downloadstation_instances,
-            self.health_instances,
-            self.container_instances,
-            self.nfs_instances,
-            self.usermgr_instances,
-        ):
+        for inst_dict in self._service_instance_dicts():
             inst_dict.pop(base_url, None)
 
     async def _handle_login(self, arguments: dict) -> list[types.TextContent]:
@@ -497,14 +498,7 @@ class SynologyMCPServer:
                 self.syno_tokens.pop(base_url, None)
 
             # Drop cached service instances so they pick up the new session/token
-            for inst_dict in (
-                self.filestation_instances,
-                self.downloadstation_instances,
-                self.health_instances,
-                self.container_instances,
-                self.nfs_instances,
-                self.usermgr_instances,
-            ):
+            for inst_dict in self._service_instance_dicts():
                 inst_dict.pop(base_url, None)
 
             return [
@@ -540,14 +534,7 @@ class SynologyMCPServer:
             # Remove session and all cached service instances on successful logout
             del self.sessions[base_url]
             self.syno_tokens.pop(base_url, None)
-            for inst_dict in (
-                self.filestation_instances,
-                self.downloadstation_instances,
-                self.health_instances,
-                self.container_instances,
-                self.nfs_instances,
-                self.usermgr_instances,
-            ):
+            for inst_dict in self._service_instance_dicts():
                 inst_dict.pop(base_url, None)
 
             return [
@@ -563,18 +550,11 @@ class SynologyMCPServer:
             error_msg = error_info.get("message", "Unknown error")
 
             # Handle expected session expiration gracefully
-            if error_code in ["105", "106", "no_session"]:
+            if str(error_code) in {"105", "106", "no_session"}:
                 # Still clean up local session data
                 del self.sessions[base_url]
                 self.syno_tokens.pop(base_url, None)
-                for inst_dict in (
-                    self.filestation_instances,
-                    self.downloadstation_instances,
-                    self.health_instances,
-                    self.container_instances,
-                    self.nfs_instances,
-                    self.usermgr_instances,
-                ):
+                for inst_dict in self._service_instance_dicts():
                     inst_dict.pop(base_url, None)
 
                 return [
@@ -2728,7 +2708,7 @@ class SynologyMCPServer:
                         error_info = result.get("error", {})
                         error_code = error_info.get("code", "unknown")
 
-                        if error_code in ["105", "106", "no_session"]:
+                        if str(error_code) in {"105", "106", "no_session"}:
                             logger.info(f"Session {session_id[:10]}... was already expired")
                             cleanup_results.append(f"{base_url}: Session already expired")
                         else:
@@ -2738,14 +2718,7 @@ class SynologyMCPServer:
                 # Always clear local data
                 del self.sessions[base_url]
                 self.syno_tokens.pop(base_url, None)
-                for inst_dict in (
-                    self.filestation_instances,
-                    self.downloadstation_instances,
-                    self.health_instances,
-                    self.container_instances,
-                    self.nfs_instances,
-                    self.usermgr_instances,
-                ):
+                for inst_dict in self._service_instance_dicts():
                     inst_dict.pop(base_url, None)
 
             except Exception as e:

--- a/tests/test_logout.py
+++ b/tests/test_logout.py
@@ -53,11 +53,15 @@ async def test_logout_clears_all_service_instance_caches():
     _assert_fully_evicted(server)
 
 
+# DSM returns numeric session codes via response.json(); "no_session" is the
+# one string code SynologyAuth.logout() emits itself. The handler must treat all
+# of them as the graceful-cleanup path.
+@pytest.mark.parametrize("error_code", [105, 106, "no_session"])
 @pytest.mark.asyncio
-async def test_expired_session_logout_clears_all_service_instance_caches():
+async def test_expired_session_logout_clears_all_service_instance_caches(error_code):
     """The expired-session branch (105/106/no_session) also evicts every cache."""
     server = _server_with_active_session(
-        {"success": False, "error": {"code": "105", "message": "session expired"}}
+        {"success": False, "error": {"code": error_code, "message": "session expired"}}
     )
 
     await server._handle_logout({"base_url": BASE_URL})

--- a/tests/test_logout.py
+++ b/tests/test_logout.py
@@ -1,0 +1,65 @@
+"""Logout cache-eviction tests (regression for issue #47)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+BASE_URL = "http://nas.example.com:5000/"
+
+# Every per-domain instance cache the server keeps keyed by base_url.
+INSTANCE_DICTS = (
+    "filestation_instances",
+    "downloadstation_instances",
+    "health_instances",
+    "container_instances",
+    "nfs_instances",
+    "usermgr_instances",
+)
+
+
+def _server_with_active_session(logout_result):
+    """Build a server with one logged-in NAS and every instance cache populated."""
+    from mcp_server import SynologyMCPServer
+
+    server = SynologyMCPServer()
+    server.sessions[BASE_URL] = "sid_xyz"
+    server.syno_tokens[BASE_URL] = "tok_abc"
+
+    auth = MagicMock()
+    auth.logout.return_value = logout_result
+    server.auth_instances[BASE_URL] = auth
+
+    # Populate each service cache with a sentinel so we can assert it gets evicted.
+    for attr in INSTANCE_DICTS:
+        getattr(server, attr)[BASE_URL] = object()
+
+    return server
+
+
+def _assert_fully_evicted(server):
+    assert BASE_URL not in server.sessions
+    assert BASE_URL not in server.syno_tokens
+    for attr in INSTANCE_DICTS:
+        assert BASE_URL not in getattr(server, attr), f"{attr} still holds the logged-out session"
+
+
+@pytest.mark.asyncio
+async def test_logout_clears_all_service_instance_caches():
+    """A successful logout evicts every per-domain cache, not just file/download station."""
+    server = _server_with_active_session({"success": True})
+
+    await server._handle_logout({"base_url": BASE_URL})
+
+    _assert_fully_evicted(server)
+
+
+@pytest.mark.asyncio
+async def test_expired_session_logout_clears_all_service_instance_caches():
+    """The expired-session branch (105/106/no_session) also evicts every cache."""
+    server = _server_with_active_session(
+        {"success": False, "error": {"code": "105", "message": "session expired"}}
+    )
+
+    await server._handle_logout({"base_url": BASE_URL})
+
+    _assert_fully_evicted(server)


### PR DESCRIPTION
## Summary

Fixes #47.

`_handle_logout` only evicted the `filestation_instances` and `downloadstation_instances` caches, leaving `health_instances`, `container_instances`, `nfs_instances`, and `usermgr_instances` holding the now-dead session id until a subsequent login resynced them.

Both code paths are fixed to iterate the same full instance-dict tuple already used by `_auto_login_if_configured`, `_resync_session_after_relogin`, `_handle_login`, and `cleanup_sessions`:
- the successful-logout branch, and
- the expired-session branch (`105` / `106` / `no_session`).

### Why it was low-severity
No incorrect-session reuse occurred in practice — every service method guards on `base_url not in self.sessions` first, and the next login resynced all caches. This is a consistency/cleanup fix that stops orphaned service instances from lingering between logout and the next login.

## Tests

Adds `tests/test_logout.py` with two async unit tests (successful logout + expired-session logout) asserting that **every** per-domain cache is evicted. Verified by-revert: both fail without the fix (a stale `health_instances` entry remains) and pass with it.

- `pytest -q -m 'not real_nas'` → 54 passed, 3 skipped, 0 failures
- `ruff check` → clean