### PR TITLE
chore(container): align version types and expose log pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,8 @@ docker-compose up
 - **`synology_container_logs`** - Get Container Manager container logs
   - `name` (required): Container name
   - `since` (optional): Log start time/filter
+  - `offset` (optional): Pagination offset (default: 0)
+  - `limit` (optional): Maximum log lines to return (default: 1000)
 - **`synology_container_resource`** - Get real-time resource usage for a Container Manager container
   - `name` (required): Container name
 - **`synology_container_project_list`** - List Container Manager projects

--- a/src/container/synology_container.py
+++ b/src/container/synology_container.py
@@ -18,22 +18,22 @@ class SynologyContainer:
     ):
         self._api = SynologyAPIClient(base_url, session_id, verify_ssl, syno_token=syno_token)
         self.container_api = "SYNO.Docker.Container"
-        self.container_version = "1"
+        self.container_version = 1
         self.project_api = "SYNO.Docker.Project"
-        self.project_version = "1"
+        self.project_version = 1
         self.image_api = "SYNO.Docker.Image"
-        self.image_version = "1"
+        self.image_version = 1
         self.registry_api = "SYNO.Docker.Registry"
-        self.registry_version = "1"
+        self.registry_version = 1
         self.network_api = "SYNO.Docker.Network"
-        self.network_version = "1"
+        self.network_version = 1
         self.container_log_api = "SYNO.Docker.Container.Log"
         self.container_resource_api = "SYNO.Docker.Container.Resource"
 
     def _make_request(
         self,
         api: str,
-        version: str,
+        version: int,
         method: str,
         **params: Any,
     ) -> Dict[str, Any]:
@@ -146,7 +146,7 @@ class SynologyContainer:
 
         return self._make_request(
             "SYNO.FileStation.CreateFolder",
-            "2",
+            2,
             "create",
             folder_path=folder_path,
             name=name,
@@ -324,7 +324,7 @@ class SynologyContainer:
         """List tags for a registry image."""
         return self._make_request(
             self.registry_api,
-            "2",
+            2,
             "tags",
             repository=repository,
             offset=str(offset),
@@ -394,6 +394,8 @@ class SynologyContainer:
         self,
         name: str,
         since: Optional[str] = None,
+        offset: int = 0,
+        limit: int = 1000,
     ) -> Dict[str, Any]:
         """Get Container Manager logs for a container."""
         params = {
@@ -403,8 +405,8 @@ class SynologyContainer:
             "level": json.dumps(""),
             "keyword": json.dumps(""),
             "sort_dir": json.dumps("DESC"),
-            "offset": "0",
-            "limit": "1000",
+            "offset": str(offset),
+            "limit": str(limit),
         }
         return self._make_request(self.container_log_api, self.container_version, "get", **params)
 

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -1291,9 +1291,14 @@ class SynologyMCPServer:
                 {
                     **name_properties,
                     "since": {"type": "string", "description": "Optional log start time/filter"},
-                    "offset": {"type": "integer", "description": "Pagination offset (default: 0)"},
+                    "offset": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Pagination offset (default: 0)",
+                    },
                     "limit": {
                         "type": "integer",
+                        "minimum": 1,
                         "description": "Maximum log lines to return (default: 1000)",
                     },
                 },

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -1050,6 +1050,8 @@ class SynologyMCPServer:
             result = container.get_container_logs(
                 arguments["name"],
                 since=arguments.get("since"),
+                offset=arguments.get("offset", 0),
+                limit=arguments.get("limit", 1000),
             )
         elif method_name in {
             "project_get",
@@ -1289,6 +1291,11 @@ class SynologyMCPServer:
                 {
                     **name_properties,
                     "since": {"type": "string", "description": "Optional log start time/filter"},
+                    "offset": {"type": "integer", "description": "Pagination offset (default: 0)"},
+                    "limit": {
+                        "type": "integer",
+                        "description": "Maximum log lines to return (default: 1000)",
+                    },
                 },
                 ["name"],
             ),

--- a/tests/test_container_manager.py
+++ b/tests/test_container_manager.py
@@ -497,6 +497,21 @@ def test_container_logs_wire_format_matches_dsm():
     assert "timestamps" not in sent_data
 
 
+def test_container_logs_forwards_custom_offset_and_limit():
+    """Caller-supplied offset/limit override the DSM pagination defaults."""
+    container = _container()
+
+    with patch(
+        "utils.synology_api.requests.post",
+        return_value=_successful_response({"logs": []}),
+    ) as post:
+        container.get_container_logs("watchtower", offset=200, limit=50)
+
+    sent_data = post.call_args.kwargs["data"]
+    assert sent_data["offset"] == "200"
+    assert sent_data["limit"] == "50"
+
+
 def test_container_tools_are_registered():
     """MCP exposes the container operations."""
     from mcp_server import SynologyMCPServer


### PR DESCRIPTION
## Summary
- Store the `SYNO.Docker.*` API versions as ints and annotate `_make_request(version: int)` to match `SynologyAPIClient.post()`; the two literal `"2"` version args (`FileStation.CreateFolder`, registry tags) become ints too. Wire format is unchanged — the client stringifies the version downstream, so DSM still receives `"1"`/`"2"`. (#45)
- Surface `offset`/`limit` on `get_container_logs` and the `synology_container_logs` tool (defaults `0`/`1000`, preserving prior behavior) instead of hardcoding the DSM log query. Agents can now page or cap container log output. (#46)

## Why
Two small Container Manager polish items from the #44 review follow-ups:
- #45 — type-annotation consistency between the module and its API client.
- #46 — the log tool previously capped output at a fixed 1000 lines with no way to page or trim.

## Test plan
- [x] `ruff check` clean
- [x] Full non-NAS suite passes (57 passed, 3 skipped)
- [x] New `test_container_logs_forwards_custom_offset_and_limit`; verify-by-revert confirms it fails without the change
- [x] Existing logs/version wire-format tests still assert `"1"`/`"2"`/`"1000"`, proving the int change is wire-compatible

Closes #45
Closes #46