### PR TITLE
chore(container): route registry tags through a registry_tags_version field

### DIFF
--- a/src/container/synology_container.py
+++ b/src/container/synology_container.py
@@ -25,6 +25,8 @@ class SynologyContainer:
         self.image_version = 1
         self.registry_api = "SYNO.Docker.Registry"
         self.registry_version = 1
+        # The registry `tags` method is served by API v2, unlike the v1 list/search/get.
+        self.registry_tags_version = 2
         self.network_api = "SYNO.Docker.Network"
         self.network_version = 1
         self.container_log_api = "SYNO.Docker.Container.Log"
@@ -324,7 +326,7 @@ class SynologyContainer:
         """List tags for a registry image."""
         return self._make_request(
             self.registry_api,
-            2,
+            self.registry_tags_version,
             "tags",
             repository=repository,
             offset=str(offset),


### PR DESCRIPTION
## Summary
- Add `self.registry_tags_version = 2` and use it in `list_registry_tags`, replacing the inline hardcoded `2`.

## Why
Every `SYNO.Docker.Registry` call routes its API version through `self.registry_version` (1) except `list_registry_tags`, which hardcoded `2`. The `tags` endpoint genuinely needs v2, but as a bare literal the special case isn't self-documenting and would silently diverge if `registry_version` were ever bumped. Naming it as a field fixes that.

## Test plan
- [x] `ruff check` clean
- [x] Full non-NAS suite passes (57 passed, 3 skipped)
- [x] No behavior change — the existing `test_registry_methods_wire_format_matches_dsm` still asserts the `tags` call sends `version == "2"`

Closes #50