### PR TITLE
feat(auth): support DSM 2FA/OTP + device-token reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,8 +619,10 @@ The MCP server supports DSM accounts with 2FA enabled. There are two ways to use
 
    **Workflow:**
    1. Set `otp_code` to a fresh 6-digit code from your authenticator and start the server.
-   2. The first successful login returns a `did` in the auto-login log line.
-   3. Paste that value into `device_id` and delete `otp_code`.
+   2. On the first successful login, the server logs a warning line like:
+      `nas1: 2FA bootstrap — copy this device_id into settings.json to skip OTP on future starts: <did>`
+      Copy the `<did>` value.
+   3. Paste it into `device_id` and delete `otp_code`.
    4. From now on, DSM treats this process as a trusted device — restarts, relogins after DSM error 119, and container-manager sessions all skip OTP.
 
    When `device_id` is present, it takes precedence over `otp_code` (trusted-device path). Legacy `.env` users can set the one-shot `SYNOLOGY_OTP_CODE` env var; for persistent `device_id`, migrate to `settings.json` (long opaque token doesn't fit an env var cleanly).

--- a/README.md
+++ b/README.md
@@ -488,11 +488,12 @@ The skill is purely additive — it works alongside the MCP and only triggers on
 > **⚠️ Security Warning: Use a Dedicated Account**
 >
 > For this MCP server, create a dedicated Synology user account with appropriate permissions. This account should:
-> - **NOT have 2FA enabled** - The MCP server cannot handle 2FA prompts and will fail authentication
 > - Have minimal required permissions only (not admin!)
 > - Be used exclusively for MCP server automation
->
-> Using your primary account with 2FA is dangerous - if auto-login fails, you may be locked out of your NAS!
+> - **2FA is now supported** — if your DSM account has 2FA enabled, see the
+>   [2FA / OTP Accounts](#2fa--otp-accounts-optional) section below to supply
+>   an `otp_code` (one-shot) or `device_id` (persistent) field. Older guidance
+>   of "no 2FA" is no longer required.
 
 ### Using settings.json (Recommended)
 
@@ -566,6 +567,8 @@ The docker-compose.yml automatically mounts your `~/.config/synology-mcp` direct
 | `port` | No | API port (default: 5000 for HTTP, 5001 for HTTPS) |
 | `username` | Yes | NAS username |
 | `password` | Yes | NAS password |
+| `otp_code` | No | One-shot 6-digit 2FA code (first login only, then remove) |
+| `device_id` | No | Long-lived trusted-device token from DSM (`did`); skip OTP on all future logins |
 | `note` | No | Optional description for your reference |
 
 **Notes:**
@@ -586,6 +589,41 @@ The docker-compose.yml automatically mounts your `~/.config/synology-mcp` direct
 - Default is `true` for convenience with settings.json
 - Credentials are stored securely in `~/.config/synology-mcp/settings.json` with 0600 permissions
 - If you prefer manual login, set `AUTO_LOGIN=false` and use the `synology_login` tool
+
+**2FA / OTP Accounts (optional):**
+
+The MCP server supports DSM accounts with 2FA enabled. There are two ways to use it:
+
+1. **One-shot OTP via `synology_login` tool** (interactive):
+   ```json
+   { "base_url": "https://nas.lan:5001", "username": "alice", "password": "…", "otp_code": "123456" }
+   ```
+   DSM will return a `did` (device token) in the response — copy that value into `settings.json` (below) to skip OTP on future process restarts.
+
+2. **Persistent trusted-device token** (recommended for `AUTO_LOGIN=true`):
+
+   Add `otp_code` (one-shot, **first login only**) and/or `device_id` (long-lived, ongoing) fields per-NAS in `settings.json`:
+
+   ```json
+   {
+     "synology": {
+       "nas1": {
+         "host": "192.168.1.100", "port": 5001,
+         "username": "alice", "password": "…",
+         "otp_code": "123456",
+         "note": "primary — 2FA enabled"
+       }
+     }
+   }
+   ```
+
+   **Workflow:**
+   1. Set `otp_code` to a fresh 6-digit code from your authenticator and start the server.
+   2. The first successful login returns a `did` in the auto-login log line.
+   3. Paste that value into `device_id` and delete `otp_code`.
+   4. From now on, DSM treats this process as a trusted device — restarts, relogins after DSM error 119, and container-manager sessions all skip OTP.
+
+   When `device_id` is present, it takes precedence over `otp_code` (trusted-device path). Legacy `.env` users can set the one-shot `SYNOLOGY_OTP_CODE` env var; for persistent `device_id`, migrate to `settings.json` (long opaque token doesn't fit an env var cleanly).
 
 ## 📖 Usage Examples
 

--- a/env.example
+++ b/env.example
@@ -6,6 +6,10 @@ SYNOLOGY_URL=https://192.168.1.100:5001
 SYNOLOGY_USERNAME=your_username
 SYNOLOGY_PASSWORD=your_password
 
+# Optional: 2FA / OTP (one-shot, first login only — for persistent reuse,
+# migrate to ~/.config/synology-mcp/settings.json and store `device_id` per-NAS)
+# SYNOLOGY_OTP_CODE=123456
+
 # Optional: Server settings
 MCP_SERVER_NAME=synology-mcp-server
 MCP_SERVER_VERSION=1.0.0

--- a/skills/synology-nas/references/auth.md
+++ b/skills/synology-nas/references/auth.md
@@ -44,17 +44,28 @@ Lives at `~/.config/synology-mcp/settings.json` (XDG standard). The file require
 ```json
 {
   "synology": {
-    "nas1": { "host": "192.168.1.100", "port": 5000, "username": "...", "password": "...", "note": "Primary" },
+    "nas1": {
+      "host": "192.168.1.100", "port": 5000,
+      "username": "...", "password": "...",
+      "note": "Primary",
+      "otp_code": "123456",
+      "device_id": "did_returned_by_dsm"
+    },
     "nas2": { "host": "192.168.1.200", "port": 5001, "username": "...", "password": "...", "note": "Backup" }
   }
 }
 ```
 
+`otp_code` and `device_id` are both optional. `device_id` wins over `otp_code`. Workflow: set `otp_code` once → start the server → copy the returned `did` into `device_id` → delete `otp_code`. From then on, OTP is no longer needed.
+
 Port 5001 enables HTTPS; anything else uses HTTP. The `note` is for the user's reference — surface it when listing NAS units to a user, since human-readable notes ("primary", "backup") are easier to reason about than `nas1`/`nas2`.
 
 ## Gotchas
 
-- **2FA**: the server can't handle 2FA prompts. If a NAS is configured with 2FA on the account, login will hang or fail. Tell the user to use a dedicated, non-admin account without 2FA for the MCP. Don't try to work around it.
+- **2FA / OTP**: the server supports DSM accounts with 2FA enabled. Two ways to log in:
+  - Interactive (one-shot): call `synology_login` with an `otp_code` argument. DSM returns a `did` in the response — that value can be pasted into `settings.json` as `device_id` for the next process start.
+  - Persistent: store `device_id` (long-lived trusted-device token) per-NAS in `settings.json`. Auto-login then skips OTP, and silent re-login after DSM error 119 also uses the device token. When `device_id` is set, `otp_code` is ignored.
+  For `.env` legacy single-NAS, `SYNOLOGY_OTP_CODE` is honored as a one-shot code on first login; for ongoing reuse, migrate to `settings.json`.
 - **Session expiry**: long-idle sessions can be invalidated by DSM. If a tool returns a session error, re-running after a `synology_login` usually fixes it. Don't loop on retry — diagnose with `synology_status` first.
 - **Stale `secrets.json` references**: some tool descriptions still say "from secrets.json". The actual file is `settings.json`. This is a docs bug in the MCP, not a config you need to recreate.
 

--- a/src/auth/synology_auth.py
+++ b/src/auth/synology_auth.py
@@ -36,9 +36,18 @@ class SynologyAuth:
         # Mirrors what login_with_session uses by default; overwritten on every login.
         self.current_session_type: str = "webui"
         self.current_syno_token: Optional[str] = None
+        # Device token returned by DSM when login includes
+        # `enable_device_token=yes` (the 2FA "remember this device" flow).
+        # Reused by relogin() so OTP isn't required on session recovery.
+        self.current_device_id: Optional[str] = None
         # Credentials cached on a successful login, used by relogin() to recover
         # from DSM session expiry without requiring a process restart.
         self._credentials: Optional[Tuple[str, str]] = None
+        # Device token cached from a prior login. Sent on relogin() as
+        # `device_id` so DSM treats us as a trusted device and skips OTP.
+        # Only populated when the original login used `enable_device_token=yes`
+        # — otherwise None, and relogin falls back to plain password auth.
+        self._cached_device_id: Optional[str] = None
         # Optional callback invoked after a successful relogin() with
         # (base_url, session_id, syno_token). Lets the caller (e.g. mcp_server)
         # resync any cached session state with the refreshed SID.
@@ -49,7 +58,13 @@ class SynologyAuth:
         # Register this instance for cross-module discovery (see _AUTH_REGISTRY).
         _AUTH_REGISTRY[self.base_url] = self
 
-    def login(self, username: str, password: str) -> Dict[str, Any]:
+    def login(
+        self,
+        username: str,
+        password: str,
+        otp_code: Optional[str] = None,
+        device_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """Authenticate with Synology NAS and return session info.
 
         Defaults to `session=webui` — the same scope the DSM web UI uses.
@@ -57,13 +72,31 @@ class SynologyAuth:
         affect which APIs are reachable (account permissions do); we
         pick `webui` for semantic alignment with the official client.
         Use `login_with_session(...)` to pick a different session type.
+
+        Auth options:
+            - `device_id`: a previously-issued DSM device token. When supplied,
+              DSM treats us as a trusted device and skips any 2FA/OTP step.
+            - `otp_code`: a one-time 6-digit code from the user's authenticator.
+              Required only on the first 2FA login (where no `device_id` is
+              available yet). When both are given, `device_id` wins and the
+              OTP is ignored — DSM won't ask for it on a trusted device.
         """
-        return self.login_with_session(username, password, "webui")
+        return self.login_with_session(
+            username, password, "webui", otp_code=otp_code, device_id=device_id
+        )
 
     def login_with_session(
-        self, username: str, password: str, session_type: str = "webui"
+        self,
+        username: str,
+        password: str,
+        session_type: str = "webui",
+        otp_code: Optional[str] = None,
+        device_id: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Authenticate with Synology NAS using specific session type."""
+        """Authenticate with Synology NAS using specific session type.
+
+        See `login()` for the meaning of `otp_code` and `device_id`.
+        """
         login_url = f"{self.base_url}/webapi/auth.cgi"
 
         # Try common API versions (start with newer versions)
@@ -84,6 +117,18 @@ class SynologyAuth:
                 # which still work pre-7.3.2).
                 "enable_syno_token": "yes",
             }
+            if device_id:
+                # Returning trusted device → DSM skips OTP. This is the path
+                # used by relogin() once we've cached a `did` from a prior
+                # 2FA login, and by callers who pre-loaded a `did` from
+                # settings.json at process start.
+                payload["device_id"] = device_id
+            elif otp_code:
+                # First-time 2FA login: include the user-supplied OTP and ask
+                # DSM to issue a device token (`did`) for reuse. Subsequent
+                # re-logins on this process use the device_id path above.
+                payload["otp_code"] = otp_code
+                payload["enable_device_token"] = "yes"
 
             try:
                 response = requests.get(login_url, params=payload, verify=self.verify_ssl)
@@ -95,6 +140,13 @@ class SynologyAuth:
                     self.current_session_id = result["data"]["sid"]
                     self.current_session_type = session_type
                     self.current_syno_token = result["data"].get("synotoken")
+                    # DSM returns `did` only when enable_device_token=yes is
+                    # honored. Cache it for relogin(); the caller may also
+                    # persist it (settings.json) to skip OTP across restarts.
+                    did = result["data"].get("did")
+                    if did:
+                        self.current_device_id = did
+                        self._cached_device_id = did
                     # Cache credentials so relogin() can recover from session expiry.
                     self._credentials = (username, password)
                     return result
@@ -109,9 +161,17 @@ class SynologyAuth:
         # If all versions failed, return the last result
         return {"success": False, "error": {"code": "unknown", "message": "Authentication failed"}}
 
-    def login_download_station(self, username: str, password: str) -> Dict[str, Any]:
+    def login_download_station(
+        self,
+        username: str,
+        password: str,
+        otp_code: Optional[str] = None,
+        device_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """Authenticate specifically for Download Station."""
-        return self.login_with_session(username, password, "DownloadStation")
+        return self.login_with_session(
+            username, password, "DownloadStation", otp_code=otp_code, device_id=device_id
+        )
 
     def relogin(self, stale_session_id: Optional[str] = None) -> bool:
         """Re-authenticate using credentials cached from the last successful login.
@@ -139,7 +199,16 @@ class SynologyAuth:
             ):
                 return True
             username, password = self._credentials
-            result = self.login_with_session(username, password, self.current_session_type)
+            # Reuse the cached device token when available: DSM treats us as
+            # a trusted device and won't require OTP. If we never had one
+            # (the initial login didn't use enable_device_token), this falls
+            # through to plain password auth — same behavior as pre-OTP.
+            result = self.login_with_session(
+                username,
+                password,
+                self.current_session_type,
+                device_id=self._cached_device_id,
+            )
             success = bool(result.get("success"))
             if success and self.on_relogin is not None:
                 # Notify the caller so it can resync cached session state with the
@@ -203,6 +272,11 @@ class SynologyAuth:
                         # otherwise a subsequent 119 would silently re-auth them
                         # against their explicit intent.
                         self._credentials = None
+                        # Also forget the trusted-device token: a user-initiated
+                        # logout ends the session deliberately, and reusing the
+                        # device_id on a later auto-relogin would contradict that.
+                        self.current_device_id = None
+                        self._cached_device_id = None
                     return result
                 else:
                     last_error = result
@@ -246,5 +320,6 @@ class SynologyAuth:
             "session_id": self.current_session_id,
             "session_type": self.current_session_type,
             "syno_token": self.current_syno_token,
+            "device_id": self.current_device_id,
             "logged_in": self.is_logged_in(),
         }

--- a/src/auth/synology_auth.py
+++ b/src/auth/synology_auth.py
@@ -140,10 +140,16 @@ class SynologyAuth:
                     self.current_session_id = result["data"]["sid"]
                     self.current_session_type = session_type
                     self.current_syno_token = result["data"].get("synotoken")
-                    # DSM returns `did` only when enable_device_token=yes is
-                    # honored. Cache it for relogin(); the caller may also
-                    # persist it (settings.json) to skip OTP across restarts.
-                    did = result["data"].get("did")
+                    # Cache the trusted-device token for relogin(). DSM only
+                    # returns `did` when the request includes
+                    # `enable_device_token=yes` (the first-time-OTP path); on
+                    # the returning-device path we send `device_id` but DSM
+                    # doesn't echo it back, so fall back to the input value.
+                    # Without this, relogin() would lose the device token
+                    # after the first successful login on the steady-state
+                    # configuration and silently fall through to plain
+                    # password auth — which DSM rejects for 2FA accounts.
+                    did = result["data"].get("did") or device_id
                     if did:
                         self.current_device_id = did
                         self._cached_device_id = did

--- a/src/config.py
+++ b/src/config.py
@@ -84,7 +84,8 @@ class SynologyConfig:
         self.synology_password = os.getenv("SYNOLOGY_PASSWORD")
         # One-shot 2FA code for legacy .env single-NAS users on first login.
         # Settings.json users store `device_id` per-NAS for ongoing reuse and
-        # don't need this. Cleared after first use by the caller.
+        # don't need this. Read-only here; auto-login consumes it but does
+        # not clear it (auto-login only runs once per process start today).
         self.synology_otp_code = os.getenv("SYNOLOGY_OTP_CODE")
 
     def _check_file_permissions(self, path: Path) -> bool:

--- a/src/config.py
+++ b/src/config.py
@@ -82,6 +82,10 @@ class SynologyConfig:
         self.synology_url = os.getenv("SYNOLOGY_URL")
         self.synology_username = os.getenv("SYNOLOGY_USERNAME")
         self.synology_password = os.getenv("SYNOLOGY_PASSWORD")
+        # One-shot 2FA code for legacy .env single-NAS users on first login.
+        # Settings.json users store `device_id` per-NAS for ongoing reuse and
+        # don't need this. Cleared after first use by the caller.
+        self.synology_otp_code = os.getenv("SYNOLOGY_OTP_CODE")
 
     def _check_file_permissions(self, path: Path) -> bool:
         """Check if secrets file has safe permissions (0600 or stricter).
@@ -144,6 +148,17 @@ class SynologyConfig:
                     port = nas_info.get("port", 5000)
                     username = nas_info.get("username", "")
                     password = nas_info.get("password", "")
+                    # Optional 2FA/OTP support (DSM Login Web API Guide):
+                    #   - `otp_code`: one-shot code from authenticator. Needed
+                    #     only on the FIRST login after enabling 2FA on the
+                    #     DSM account. After that first login, DSM issues a
+                    #     device token (`did`); paste it as `device_id` and
+                    #     remove `otp_code`.
+                    #   - `device_id`: long-lived trusted-device token. When
+                    #     present, DSM skips OTP for this login and for the
+                    #     silent re-auth path (DSM error 119 recovery).
+                    otp_code = nas_info.get("otp_code") or None
+                    device_id = nas_info.get("device_id") or None
 
                     if not host:
                         logger.warning(f"Missing 'host' for NAS '{nas_name}' in {SETTINGS_FILE}")
@@ -168,6 +183,8 @@ class SynologyConfig:
                         "password": password,
                         "verify_ssl": self.verify_ssl,
                         "note": nas_info.get("note", ""),
+                        "otp_code": otp_code,
+                        "device_id": device_id,
                     }
 
                 # Load Xiaozhi settings
@@ -246,6 +263,8 @@ class SynologyConfig:
             "username": self.synology_username,
             "password": self.synology_password,
             "verify_ssl": self.verify_ssl,
+            "otp_code": self.synology_otp_code,
+            "device_id": None,
         }
 
     def resolve_base_url(self, nas_name: str) -> Optional[str]:

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -177,7 +177,15 @@ class SynologyMCPServer:
 
                 auth = self.auth_instances[base_url]
                 auth.on_relogin = self._resync_session_after_relogin
-                result = auth.login(nas_cfg["username"], nas_cfg["password"])
+                # Pass optional 2FA material from settings.json (or legacy .env
+                # for otp_code). device_id wins over otp_code; both None means
+                # the DSM account has 2FA off (existing behavior).
+                result = auth.login(
+                    nas_cfg["username"],
+                    nas_cfg["password"],
+                    otp_code=nas_cfg.get("otp_code"),
+                    device_id=nas_cfg.get("device_id"),
+                )
 
                 if result.get("success"):
                     session_id = result["data"]["sid"]
@@ -223,7 +231,14 @@ class SynologyMCPServer:
                     [
                         types.Tool(
                             name="synology_login",
-                            description="Authenticate with Synology NAS and establish session",
+                            description=(
+                                "Authenticate with Synology NAS and establish session.\n\n"
+                                "2FA/OTP accounts: pass `otp_code` on the first login only; "
+                                "DSM will issue a `device_id` in the response, which you can "
+                                "persist into settings.json to skip OTP on future logins. If "
+                                "you already have a `device_id`, pass it instead of `otp_code` "
+                                "— DSM treats trusted devices as already authenticated."
+                            ),
                             inputSchema={
                                 "type": "object",
                                 "properties": {
@@ -238,6 +253,23 @@ class SynologyMCPServer:
                                     "password": {
                                         "type": "string",
                                         "description": "Password for authentication",
+                                    },
+                                    "otp_code": {
+                                        "type": "string",
+                                        "description": (
+                                            "One-time 6-digit code from the user's authenticator. "
+                                            "Required only on the first 2FA login for a new device. "
+                                            "Ignored when `device_id` is also given."
+                                        ),
+                                    },
+                                    "device_id": {
+                                        "type": "string",
+                                        "description": (
+                                            "Long-lived trusted-device token previously issued by DSM "
+                                            "(returned as `did` in a successful 2FA login). When "
+                                            "supplied, DSM skips the OTP step. Preferred over "
+                                            "`otp_code` for repeated logins."
+                                        ),
                                     },
                                 },
                                 "required": ["base_url", "username", "password"],
@@ -466,6 +498,11 @@ class SynologyMCPServer:
         base_url = arguments["base_url"]
         username = arguments["username"]
         password = arguments["password"]
+        # Both 2FA fields are optional. When both are supplied, `device_id`
+        # wins (DSM won't ask for OTP on a trusted device). When neither is
+        # supplied, behavior matches pre-2FA support.
+        otp_code = arguments.get("otp_code")
+        device_id = arguments.get("device_id")
 
         # Validate base_url format
         if not self._validate_url(base_url):
@@ -485,7 +522,7 @@ class SynologyMCPServer:
         auth.on_relogin = self._resync_session_after_relogin
 
         # Perform login
-        result = auth.login(username, password)
+        result = auth.login(username, password, otp_code=otp_code, device_id=device_id)
 
         # Store session if successful
         if result.get("success"):

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -199,6 +199,20 @@ class SynologyMCPServer:
                     self.nas_name_map[label] = base_url
                     if nas_name is None:
                         self.nas_name_map[base_url] = base_url
+                    # Surface the DSM device token so users can copy it into
+                    # settings.json (`device_id`) to skip OTP on future starts.
+                    # Only present when DSM issued one — i.e. the first-time
+                    # OTP login (the steady-state `device_id` path doesn't
+                    # echo it back). Logged in full because (a) the value
+                    # is destined for settings.json anyway and (b) it's
+                    # useless without the password, so truncation provides
+                    # no meaningful protection.
+                    did = result["data"].get("did")
+                    if did:
+                        logger.warning(
+                            f"{label}: 2FA bootstrap — copy this device_id into "
+                            f"settings.json to skip OTP on future starts: {did}"
+                        )
                     logger.info(f"{label}: session {session_id[:8]}...")
 
                     for inst_dict in self._service_instance_dicts():

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -266,3 +266,195 @@ def test_relogin_skips_when_session_already_refreshed():
     # This caller saw OLD_SID get the 119; current is already NEW_SID → skip.
     assert auth.relogin(stale_session_id="OLD_SID") is True
     assert auth.current_session_id == "NEW_SID"
+
+
+# ---------------------------------------------------------------------------
+# OTP + device-token unit tests (no live NAS required)
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Minimal stand-in for requests.Response used by the OTP payload tests."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def _patch_requests_get(monkeypatch, payloads):
+    """Replace requests.get in synology_auth with a recorder.
+
+    `payloads` is a list of dicts; each call pops the head. Every call also
+    records the params it was called with into `calls` for assertions.
+    """
+    import auth.synology_auth as mod
+
+    calls = []
+
+    def _fake_get(url, params=None, verify=None):
+        calls.append({"url": url, "params": dict(params or {}), "verify": verify})
+        return _FakeResponse(payloads.pop(0) if payloads else {"success": False})
+
+    monkeypatch.setattr(mod.requests, "get", _fake_get)
+    return calls
+
+
+def test_login_with_otp_code_adds_otp_and_device_token_request(monkeypatch):
+    """First-time 2FA login: payload includes `otp_code` + `enable_device_token=yes`
+    so DSM both accepts the OTP AND returns a `did` for future reuse."""
+    from auth.synology_auth import SynologyAuth
+
+    success_payload = {
+        "success": True,
+        "data": {"sid": "SID_123", "synotoken": "SYNO_TOK", "did": "DID_abc"},
+    }
+    calls = _patch_requests_get(monkeypatch, [success_payload])
+
+    auth = SynologyAuth("https://nas.example.test:5001")
+    auth.login("alice", "pw", otp_code="123456")
+
+    assert len(calls) == 1
+    params = calls[0]["params"]
+    assert params["otp_code"] == "123456"
+    assert params["enable_device_token"] == "yes"
+    # Device-id path must NOT be taken when we're sending an OTP.
+    assert "device_id" not in params
+
+
+def test_login_with_device_id_trusted_device_path(monkeypatch):
+    """Returning trusted device: payload includes `device_id` and skips both
+    `otp_code` and `enable_device_token` — DSM treats the call as already
+    authenticated."""
+    from auth.synology_auth import SynologyAuth
+
+    success_payload = {"success": True, "data": {"sid": "SID_456", "synotoken": "T"}}
+    calls = _patch_requests_get(monkeypatch, [success_payload])
+
+    auth = SynologyAuth("https://nas.example.test:5001")
+    auth.login("alice", "pw", device_id="DID_abc")
+
+    assert len(calls) == 1
+    params = calls[0]["params"]
+    assert params["device_id"] == "DID_abc"
+    assert "otp_code" not in params
+    assert "enable_device_token" not in params
+
+
+def test_device_id_wins_over_otp_code(monkeypatch):
+    """When both are passed, device_id wins — DSM won't ask for OTP on a
+    trusted device, so we don't send one."""
+    from auth.synology_auth import SynologyAuth
+
+    success_payload = {"success": True, "data": {"sid": "SID_789", "synotoken": "T"}}
+    calls = _patch_requests_get(monkeypatch, [success_payload])
+
+    auth = SynologyAuth("https://nas.example.test:5001")
+    auth.login("alice", "pw", otp_code="123456", device_id="DID_abc")
+
+    params = calls[0]["params"]
+    assert params["device_id"] == "DID_abc"
+    assert "otp_code" not in params
+    assert "enable_device_token" not in params
+
+
+def test_successful_otp_login_caches_did_for_relogin(monkeypatch):
+    """A login that returns `did` must cache it so relogin() can reuse the
+    trusted-device path instead of asking the user for OTP again."""
+    from auth.synology_auth import SynologyAuth
+
+    success_payload = {
+        "success": True,
+        "data": {"sid": "SID_1", "synotoken": "T", "did": "DID_persisted"},
+    }
+    _patch_requests_get(monkeypatch, [success_payload])
+
+    auth = SynologyAuth("https://nas.example.test:5001")
+    auth.login("alice", "pw", otp_code="123456")
+
+    assert auth.current_device_id == "DID_persisted"
+    assert auth._cached_device_id == "DID_persisted"
+
+
+def test_successful_login_without_device_token_leaves_cache_empty(monkeypatch):
+    """Plain 2FA-off login must not populate the device-id cache — relogin
+    should fall back to plain password auth (legacy behavior)."""
+    from auth.synology_auth import SynologyAuth
+
+    success_payload = {"success": True, "data": {"sid": "SID_2", "synotoken": "T"}}
+    _patch_requests_get(monkeypatch, [success_payload])
+
+    auth = SynologyAuth("https://nas.example.test:5001")
+    auth.login("alice", "pw")
+
+    assert auth.current_device_id is None
+    assert auth._cached_device_id is None
+
+
+def test_relogin_reuses_cached_device_id(monkeypatch):
+    """relogin() after a 2FA login must pass the cached did as `device_id`
+    so DSM doesn't ask for OTP on session recovery (error 119 path)."""
+    from auth.synology_auth import SynologyAuth
+
+    initial = {
+        "success": True,
+        "data": {"sid": "SID_OLD", "synotoken": "T_OLD", "did": "DID_reuse"},
+    }
+    refreshed = {
+        "success": True,
+        "data": {"sid": "SID_NEW", "synotoken": "T_NEW", "did": "DID_reuse"},
+    }
+    calls = _patch_requests_get(monkeypatch, [initial, refreshed])
+
+    auth = SynologyAuth("https://nas.example.test:5001")
+    auth.login("alice", "pw", otp_code="111222")
+    # Pre-arm a different SID so relogin doesn't no-op under the "already
+    # refreshed" guard.
+    stale = auth.current_session_id
+    auth.current_session_id = stale  # unchanged; relogin sees no change
+
+    # Force a relogin call that actually hits login_with_session.
+    assert auth.relogin() is True
+
+    # Second call (relogin) must include device_id; no otp_code/enable_device_token.
+    relogin_params = calls[1]["params"]
+    assert relogin_params["device_id"] == "DID_reuse"
+    assert "otp_code" not in relogin_params
+    assert "enable_device_token" not in relogin_params
+
+
+def test_logout_clears_device_id_cache(monkeypatch):
+    """User-initiated logout forgets the trusted-device token, mirroring the
+    cached-credentials drop — otherwise a later 119 would silently re-auth
+    against the user's explicit logout."""
+    from auth.synology_auth import SynologyAuth
+
+    login_payload = {
+        "success": True,
+        "data": {"sid": "SID_3", "synotoken": "T", "did": "DID_forget_me"},
+    }
+    logout_payload = {"success": True}
+    _patch_requests_get(monkeypatch, [login_payload, logout_payload])
+
+    auth = SynologyAuth("https://nas.example.test:5001")
+    auth.login("alice", "pw", otp_code="333444")
+    assert auth._cached_device_id == "DID_forget_me"
+
+    auth.logout()
+    assert auth.current_device_id is None
+    assert auth._cached_device_id is None
+
+
+def test_get_session_info_includes_device_id():
+    """get_session_info surfaces device_id so callers (e.g. mcp_server status
+    tool) can show the operator whether the session is OTP-exempt."""
+    from auth.synology_auth import SynologyAuth
+
+    auth = SynologyAuth("https://nas.example.test:5001")
+    auth.current_device_id = "DID_visible"
+    info = auth.get_session_info()
+    assert info["device_id"] == "DID_visible"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -395,6 +395,34 @@ def test_successful_login_without_device_token_leaves_cache_empty(monkeypatch):
     assert auth._cached_device_id is None
 
 
+def test_login_with_explicit_device_id_seeds_cache_for_relogin(monkeypatch):
+    """Steady-state 2FA config: user has pasted `did` into settings.json as
+    `device_id`. The returning-device login path doesn't get `did` echoed
+    back by DSM, so the cache must be seeded from the INPUT device_id —
+    otherwise the next relogin() would silently fall through to plain
+    password auth (which DSM rejects for 2FA accounts)."""
+    from auth.synology_auth import SynologyAuth
+
+    # DSM response on the device_id path: no `did` field echoed.
+    success_payload = {"success": True, "data": {"sid": "SID_steady", "synotoken": "T"}}
+    calls = _patch_requests_get(monkeypatch, [success_payload, success_payload])
+
+    auth = SynologyAuth("https://nas.example.test:5001")
+    auth.login("alice", "pw", device_id="DID_from_settings")
+
+    # Cache seeded from input despite no `did` in response.
+    assert auth.current_device_id == "DID_from_settings"
+    assert auth._cached_device_id == "DID_from_settings"
+
+    # Relogin must reuse the cached did — not fall through to password-only.
+    auth.current_session_id = "SID_ABOUT_TO_EXPIRE"
+    assert auth.relogin() is True
+
+    relogin_params = calls[1]["params"]
+    assert relogin_params["device_id"] == "DID_from_settings"
+    assert "otp_code" not in relogin_params
+
+
 def test_relogin_reuses_cached_device_id(monkeypatch):
     """relogin() after a 2FA login must pass the cached did as `device_id`
     so DSM doesn't ask for OTP on session recovery (error 119 path)."""


### PR DESCRIPTION
## Summary

- Add DSM 2FA/OTP support to `SYNO.API.Auth` login so accounts with 2FA enabled can be used without the prior "create a non-2FA account" security downgrade.
- Implement DSM's trusted-device flow: first-time login with `otp_code` returns a `did` (device token); subsequent logins pass `device_id` and skip OTP entirely.
- `relogin()` (DSM error 119 recovery path) reuses the cached `did`, so silent session recovery keeps working on 2FA accounts.

## Why

Issue #54 tracked moving off stored DSM passwords. The investigation in that issue showed that full OAuth-for-API-access is blocked by Synology (their SSO Server only issues `user_id`-scope tokens; DSM WebAPI requires an `SYNO.API.Auth` `sid`), and recommended **Option B (OTP + device token)** as the realistic improvement that fits DSM's actual auth model. This PR implements that option.

Concretely:
- `src/auth/synology_auth.py` — `login()`, `login_with_session()`, `login_download_station()` accept optional `otp_code` and `device_id`. The auth payload branches: `device_id` wins, otherwise `otp_code` + `enable_device_token=yes`. The returned `did` is cached for relogin.
- `src/config.py` — per-NAS `otp_code` and `device_id` loaded from `settings.json`; legacy `.env` users get a one-shot `SYNOLOGY_OTP_CODE`.
- `src/mcp_server.py` — auto-login and the `synology_login` tool thread the new fields through; tool schema documents the 2FA workflow.
- Docs — README, `env.example`, and the Claude Code skill at `skills/synology-nas/references/auth.md` all updated with the new workflow.

What's **not** in this PR (intentionally, to keep diff narrow):
- Option A (session-only storage, no password) — needs its own UX decision for long-running servers; will be a separate PR if pursued.
- Auto-persisting the returned `did` back into `settings.json` after first login. The user copies it manually for now; safe default, smaller surface.

## Test plan

- [x] `ruff check` passes.
- [x] `black --check` passes on all modified files.
- [x] `mypy src/auth/synology_auth.py src/config.py` passes.
- [x] Full suite: 65 passed, 40 skipped (real-NAS) — `pytest`.
- [x] 9 new unit tests cover OTP path, device_id path, precedence (device_id wins), did caching, relogin reuse, logout cleanup, and session-info surfacing — all run without a live NAS.
- [ ] Live 2FA account verification — requires a real NAS with 2FA enabled; documented in README workflow.

Closes #54
