### PR TITLE
fix(health): query SMART attributes from the API that serves them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- `synology_disk_smart` never returned SMART attributes. `disk_smart_info()` queried `SYNO.Core.Storage.Disk/get_smart_info`, which does not exist on DSM 6 or 7, and its DSM 6 fallback called `SYNO.Storage.CGI.Smart/get` **without forwarding `extra_params`** — asking DSM for SMART data without naming a disk. On DSM 7.3.2 the tool returned error 103; on DSM 7.1.1 it returned `success: true` with an empty `hddinfo`, so a monitoring caller saw "no problems" from a query that never looked at a drive. The attribute table now comes from `SYNO.Storage.CGI.Smart/get_smart_info` keyed by the disk's **device path** (`device=/dev/sata1`); a bare name is rejected by DSM with error 117, so `disk_id` accepts either the id (`sata1`, `sda`, `nvme0n1`) or a full `/dev` path and is normalized, falling back to a `disk_list()` lookup when the two diverge. Verified against DSM 7.1.1-42962 (DS214play) and DSM 7.3.2-86009 (RS822RP+), returning 19–20 attributes per drive.
+
 ## [1.5.0] - 2026-06-27
 
 ### Added

--- a/src/health/synology_health.py
+++ b/src/health/synology_health.py
@@ -78,15 +78,36 @@ class SynologyHealth:
             return {"success": True, "data": {"disks": storage["data"].get("disks", [])}}
         return storage
 
+    def _disk_device_path(self, disk_id: str) -> Optional[str]:
+        """Resolve a disk id ("sata1", "sda") to its /dev path via the disk list."""
+        disks = self.disk_list().get("data", {}).get("disks", []) or []
+        for disk in disks:
+            if disk.get("id") == disk_id:
+                return disk.get("device")
+        return None
+
     def disk_smart_info(self, disk_id: str) -> Dict[str, Any]:
-        """Get detailed SMART attributes for a specific disk."""
+        """Get detailed SMART attributes for a specific disk.
+
+        DSM serves the attribute table from SYNO.Storage.CGI.Smart/get_smart_info
+        keyed by the disk's **device path**; a bare name like "sata1" is rejected
+        with error 117. disk_list() reports both forms (`id` and `device`), so
+        accept either here and normalize.
+        """
+        device = disk_id if disk_id.startswith("/dev/") else f"/dev/{disk_id}"
         result = self._api_call(
-            "SYNO.Core.Storage.Disk", "get_smart_info", extra_params={"disk": disk_id}
+            "SYNO.Storage.CGI.Smart", "get_smart_info", extra_params={"device": device}
         )
         if result.get("success"):
             return result
-        # DSM 6 fallback
-        return self._api_call("SYNO.Storage.CGI.Smart", "get")
+        # The constructed path can be wrong where a disk's id and device name
+        # diverge (e.g. external enclosures); resolve it from the disk list.
+        resolved = self._disk_device_path(disk_id)
+        if resolved and resolved != device:
+            return self._api_call(
+                "SYNO.Storage.CGI.Smart", "get_smart_info", extra_params={"device": resolved}
+            )
+        return result
 
     def volume_list(self) -> Dict[str, Any]:
         """List all volumes with status, size, usage, filesystem type."""

--- a/src/health/synology_health.py
+++ b/src/health/synology_health.py
@@ -108,11 +108,13 @@ class SynologyHealth:
         # diverge (e.g. external enclosures); resolve it from the disk list.
         resolved = self._disk_device_path(disk_id)
         if resolved and resolved != device:
-            retry = self._api_call(
+            # The constructed path was our own guess and the disk list just
+            # proved it wrong, so the resolved device is authoritative: the
+            # retry's result — success or failure — is the real answer.
+            # Surface its error rather than the speculative path's 117.
+            return self._api_call(
                 "SYNO.Storage.CGI.Smart", "get_smart_info", extra_params={"device": resolved}
             )
-            # Keep the original (more specific) error if the retry also fails.
-            return retry if retry.get("success") else result
         return result
 
     def volume_list(self) -> Dict[str, Any]:

--- a/src/health/synology_health.py
+++ b/src/health/synology_health.py
@@ -100,13 +100,19 @@ class SynologyHealth:
         )
         if result.get("success"):
             return result
+        # A rejected full /dev path can't be improved by the disk list (the
+        # list can only resolve bare ids), so don't pay for the extra call.
+        if disk_id.startswith("/dev/"):
+            return result
         # The constructed path can be wrong where a disk's id and device name
         # diverge (e.g. external enclosures); resolve it from the disk list.
         resolved = self._disk_device_path(disk_id)
         if resolved and resolved != device:
-            return self._api_call(
+            retry = self._api_call(
                 "SYNO.Storage.CGI.Smart", "get_smart_info", extra_params={"device": resolved}
             )
+            # Keep the original (more specific) error if the retry also fails.
+            return retry if retry.get("success") else result
         return result
 
     def volume_list(self) -> Dict[str, Any]:

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -2058,7 +2058,7 @@ class SynologyMCPServer:
                         },
                         "disk_id": {
                             "type": "string",
-                            "description": "Disk identifier (e.g. 'sda', 'sdb') from synology_disk_health output",
+                            "description": "Disk identifier from synology_disk_health output — either the disk id (e.g. 'sata1', 'sda', 'nvme0n1') or its device path (e.g. '/dev/sata1')",
                         },
                     },
                     "required": ["disk_id"],

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -246,6 +246,63 @@ class TestSystemInfoFallback:
         assert not result.get("success")
 
 
+class TestDiskSmartInfo:
+    """Unit tests for disk_smart_info API coordinates (no live NAS required)."""
+
+    SMART_OK = {"success": True, "data": {"smartInfo": [{"id": 5, "name": "Realloc_Sector_Ct"}]}}
+
+    def _make_health(self):
+        from health.synology_health import SynologyHealth
+
+        return SynologyHealth("http://nas:5000", "fake-sid", verify_ssl=False)
+
+    def test_queries_smart_cgi_with_device_path(self):
+        """Uses SYNO.Storage.CGI.Smart/get_smart_info keyed by /dev path."""
+        health = self._make_health()
+        with patch.object(health._api, "get", return_value=self.SMART_OK) as mock_get:
+            result = health.disk_smart_info("sata1")
+        assert result == self.SMART_OK
+        mock_get.assert_called_once_with(
+            "SYNO.Storage.CGI.Smart", "get_smart_info", 1, {"device": "/dev/sata1"}
+        )
+
+    def test_device_path_passed_through(self):
+        """An already-qualified /dev path is not prefixed twice."""
+        health = self._make_health()
+        with patch.object(health._api, "get", return_value=self.SMART_OK) as mock_get:
+            health.disk_smart_info("/dev/sda")
+        assert mock_get.call_args[0][3] == {"device": "/dev/sda"}
+
+    def test_resolves_device_via_disk_list(self):
+        """Falls back to the disk list when the constructed path is rejected."""
+        health = self._make_health()
+
+        def side_effect(api, method, version=1, extra_params=None):
+            if api == "SYNO.Core.Storage.Disk" and method == "list":
+                return {"success": True, "data": {"disks": [{"id": "usb1", "device": "/dev/sdq"}]}}
+            if extra_params == {"device": "/dev/sdq"}:
+                return self.SMART_OK
+            return {"success": False, "error": {"code": 117}}
+
+        with patch.object(health._api, "get", side_effect=side_effect):
+            result = health.disk_smart_info("usb1")
+        assert result == self.SMART_OK
+
+    def test_never_queries_without_a_disk(self):
+        """Regression: every SMART call must name a disk (see issue: empty hddinfo)."""
+        health = self._make_health()
+        with patch.object(
+            health._api, "get", return_value={"success": False, "error": {"code": 117}}
+        ) as mock_get:
+            health.disk_smart_info("sata1")
+
+        smart_calls = [c for c in mock_get.call_args_list if c[0][0] == "SYNO.Storage.CGI.Smart"]
+        assert smart_calls, "no SMART API call was made"
+        for call in smart_calls:
+            assert call[0][3], f"SMART call made with no disk parameter: {call}"
+            assert "device" in call[0][3]
+
+
 def test_health_url_construction():
     """Test URL handling in health module."""
     from health.synology_health import SynologyHealth

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -302,6 +302,31 @@ class TestDiskSmartInfo:
             assert call[0][3], f"SMART call made with no disk parameter: {call}"
             assert "device" in call[0][3]
 
+    def test_dev_path_failure_skips_disk_list(self):
+        """A rejected /dev path is returned as-is; no disk_list lookup is wasted."""
+        health = self._make_health()
+        fail = {"success": False, "error": {"code": 117}}
+        with patch.object(health._api, "get", return_value=fail) as mock_get:
+            result = health.disk_smart_info("/dev/sdq")
+        assert result == fail
+        assert mock_get.call_count == 1
+
+    def test_failed_retry_preserves_original_error(self):
+        """If the disk-list retry also fails, the original error is returned."""
+        health = self._make_health()
+        original = {"success": False, "error": {"code": 117}}
+
+        def side_effect(api, method, version=1, extra_params=None):
+            if api == "SYNO.Core.Storage.Disk" and method == "list":
+                return {"success": True, "data": {"disks": [{"id": "usb1", "device": "/dev/sdq"}]}}
+            if extra_params == {"device": "/dev/sdq"}:
+                return {"success": False, "error": {"code": "network_error"}}
+            return original
+
+        with patch.object(health._api, "get", side_effect=side_effect):
+            result = health.disk_smart_info("usb1")
+        assert result == original
+
 
 def test_health_url_construction():
     """Test URL handling in health module."""

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -311,21 +311,22 @@ class TestDiskSmartInfo:
         assert result == fail
         assert mock_get.call_count == 1
 
-    def test_failed_retry_preserves_original_error(self):
-        """If the disk-list retry also fails, the original error is returned."""
+    def test_failed_retry_surfaces_retry_error(self):
+        """Once the disk list resolves the authoritative device, the retry's
+        error is the real failure — the speculative path's 117 is discarded."""
         health = self._make_health()
-        original = {"success": False, "error": {"code": 117}}
+        retry_fail = {"success": False, "error": {"code": "network_error"}}
 
         def side_effect(api, method, version=1, extra_params=None):
             if api == "SYNO.Core.Storage.Disk" and method == "list":
                 return {"success": True, "data": {"disks": [{"id": "usb1", "device": "/dev/sdq"}]}}
             if extra_params == {"device": "/dev/sdq"}:
-                return {"success": False, "error": {"code": "network_error"}}
-            return original
+                return retry_fail
+            return {"success": False, "error": {"code": 117}}
 
         with patch.object(health._api, "get", side_effect=side_effect):
             result = health.disk_smart_info("usb1")
-        assert result == original
+        assert result == retry_fail
 
 
 def test_health_url_construction():


### PR DESCRIPTION
## Summary

`synology_disk_smart` never returns SMART attributes — on **any** DSM version I could test. This fixes the API coordinates it uses, and adds unit coverage so the regression can't come back silently.

The failure is worse than a plain error, because on DSM 7.1.x it fails *successfully*: the tool returns `success: true` with an empty payload, so a monitoring caller sees a clean result from a query that never looked at a drive.

## Root cause

```python
def disk_smart_info(self, disk_id: str) -> Dict[str, Any]:
    result = self._api_call(
        "SYNO.Core.Storage.Disk", "get_smart_info", extra_params={"disk": disk_id}
    )
    if result.get("success"):
        return result
    # DSM 6 fallback
    return self._api_call("SYNO.Storage.CGI.Smart", "get")   # <-- extra_params dropped
```

Three separate problems:

1. **`SYNO.Core.Storage.Disk` has no `get_smart_info` method.** That API exposes `list`, not SMART attributes. DSM answers with error `103` (method does not exist).
2. **The DSM 6 fallback silently discards `extra_params`.** It asks `SYNO.Storage.CGI.Smart/get` for SMART data without ever naming a disk.
3. **`SYNO.Storage.CGI.Smart/get` is the self-test *history* endpoint, not the attribute table.** Its payload is `{extend_last, hddinfo, latest_test_time, quick_last, testInfo}` — SMART test results, a different thing from the attribute list.

Two different symptoms fall out, depending on DSM version:

| DSM | Behaviour before this PR |
|---|---|
| 7.3.2-86009 | Primary → `103`; legacy API is gone too → tool returns `{"success": false, "error": {"code": 103}}` |
| 7.1.1-42962 | Primary → `103`; legacy API still exists → returns **`success: true` with `hddinfo: []`** |

That second row is the dangerous one. A caller asking "is this disk healthy?" gets a successful, empty answer.

## Finding the correct API

Querying `SYNO.API.Info` shows `SYNO.Storage.CGI.Smart v1-1` is present on both DSM 7.1.1 and 7.3.2. Probing its methods:

| Method | Result |
|---|---|
| `get` | `success` — but returns self-test history, not attributes |
| `get_attr`, `get_smart_attr`, `get_disk_smart`, `info` | `103` (no such method) |
| `list` | `121` |
| **`get_smart_info`** | **`114` — missing required parameter** ✅ |

`114` proves the method exists and just wasn't being given what it needs. Probing parameter names against it:

| Parameter | Value | Result |
|---|---|---|
| `disk`, `disk_id`, `diskno`, `name`, `hdd`, `path`, `id`, `target`, `dev` | either form | `114` |
| `device` | `sda` | `117` (unknown parameter value) |
| **`device`** | **`/dev/sda`** | **success — `smartInfo` with 20 attributes** ✅ |

So the endpoint is `SYNO.Storage.CGI.Smart/get_smart_info`, keyed by `device`, and it requires the **full device path**. A bare disk name is explicitly rejected.

## The fix

- Query `SYNO.Storage.CGI.Smart/get_smart_info` with `device=<path>`.
- `disk_id` accepts either what `synology_disk_health` reports as the disk `id` (`sata1`, `sda`, `nvme0n1`) or an already-qualified `/dev` path, and normalizes it — so existing callers don't have to change.
- If the constructed path is rejected (a disk whose `id` and device name diverge, e.g. external enclosures), fall back to resolving `device` from `disk_list()`, which already returns both fields.
- Updated the `disk_id` tool description to document both accepted forms.

I deliberately did **not** keep a legacy fallback here: `SYNO.Storage.CGI.Smart` is the older CGI-era API name and is present on both DSM 7.1.1 and 7.3.2, so it is already the more portable of the two choices. Pointing the fallback at an endpoint that returns a different data shape is what produced the silent-empty-success in the first place.

## Testing

**New unit tests** (`TestDiskSmartInfo`, mock-based, no NAS required — follows the existing `TestSystemInfoFallback` pattern):

- `test_queries_smart_cgi_with_device_path` — asserts the exact API/method/params tuple
- `test_device_path_passed_through` — a `/dev/...` argument isn't prefixed twice
- `test_resolves_device_via_disk_list` — the divergent-name fallback path
- `test_never_queries_without_a_disk` — **direct regression guard**: every SMART call must carry a `device` parameter, which is precisely what the old fallback dropped

Full suite: **70 passed, 40 skipped** (skips are the `real_nas` tests, no credentials in that environment). No existing tests changed.

**Live hardware**, patched code against two DSM generations:

| Model | DSM | Disk | Result |
|---|---|---|---|
| RS822RP+ | 7.3.2-86009 | `sata1` | ✅ 19 attributes |
| RS822RP+ | 7.3.2-86009 | `sata1` | ✅ 19 attributes |
| DS214play | 7.1.1-42962 | `sda` | ✅ 20 attributes |
| DS214play | 7.1.1-42962 | `sdb` | ✅ 20 attributes |

Cross-validated against `smartctl -d sat -A` over SSH on the same drives — power-on-hours, reallocated-sector, and pending-sector values match the API output exactly.

Note the returned attribute dicts use `name` (not `attrName`) alongside `id`, `raw`, `current`, `worst`, `threshold`, `status`.

## Compatibility

`disk_id` remains a plain string and previously-documented values (`sda`, `sdb`) still work, so this is not a breaking change for callers. I have no DSM 6 hardware to test on; `SYNO.Storage.CGI.Smart` is the DSM 6-era API name, so it should be at least as compatible as what it replaces — happy to adjust if you know otherwise.
