### PR TITLE
fix: point websockets install hint at requirements.txt

### DIFF
--- a/main.py
+++ b/main.py
@@ -53,7 +53,7 @@ def check_requirements():
 
         if importlib.util.find_spec("websockets") is None:
             errors.append(
-                "websockets package is not installed. Run: pip install websockets>=11.0.3"
+                "websockets package is not installed. Run: pip install -r requirements.txt"
             )
 
     return errors


### PR DESCRIPTION
## Summary

The config-validation error in `main.py` told users to `pip install websockets>=11.0.3`, which had drifted from the actual floor in `requirements.txt` (`>=16.1`, and `>=16.1.1` once #58 merges). It now points at `requirements.txt` so the hint can't go stale again.

Flagged by three independent reviews on #58.

## Testing

- Suite: 107 passed, 3 skipped (the 2 failures are the known pre-existing `.env`-dependent ones, reproducible on `main`)
- No test asserts the old string