### PR TITLE
Extend DSM 119 auto-recovery to FileStation

### DIFF
--- a/src/filestation/synology_filestation.py
+++ b/src/filestation/synology_filestation.py
@@ -1,6 +1,7 @@
 # src/synology_filestation.py - Synology FileStation API utilities
 
 import json
+import logging
 import os
 import tempfile
 import time
@@ -8,6 +9,8 @@ import unicodedata
 from typing import Any, Dict, List, Optional
 
 import requests
+
+logger = logging.getLogger(__name__)
 
 
 class SynologyFileStation:
@@ -46,14 +49,21 @@ class SynologyFileStation:
         the relogin fails, in which case the caller keeps the original error.
 
         Import is deferred to runtime to avoid a circular import
-        (auth -> filestation).
+        (auth -> filestation). `stale_session_id` is passed through to
+        `SynologyAuth.relogin()` so that concurrent recoveries collapse into a
+        single relogin (matching SynologyAPIClient's behavior).
         """
+        stale_session_id = self.session_id
         try:
             from auth.synology_auth import get_auth_for_url
-        except ImportError:
+        except ImportError as exc:
+            # Deferred to dodge a circular import; a real failure here (e.g. a
+            # syntax error introduced in synology_auth) would otherwise silently
+            # leave the caller stuck on the 119. Log it so it's observable.
+            logger.warning("Cannot recover from DSM error 119 — auth module unavailable: %s", exc)
             return False
         auth = get_auth_for_url(self.base_url)
-        if auth is None or not auth.relogin():
+        if auth is None or not auth.relogin(stale_session_id):
             return False
         self.session_id = auth.current_session_id
         self.syno_token = auth.current_syno_token
@@ -132,7 +142,15 @@ class SynologyFileStation:
     def _make_upload_request(
         self, api: str, version: str, method: str, files: Dict[str, Any], **params
     ) -> Dict[str, Any]:
-        """Make an upload request to Synology API."""
+        """Make an upload request to Synology API.
+
+        NOTE: this path deliberately does NOT recover from DSM error 119, unlike
+        `_make_request`. Uploads are multipart and `files` holds file streams
+        that have already been consumed by the first attempt; a blind replay
+        would send truncated content. Retrying safely needs stream rewinding or
+        re-opening the file, which is a larger change than this method should
+        take on. A 119 here surfaces to the caller as-is.
+        """
         request_params = {
             "api": api,
             "version": version,

--- a/src/filestation/synology_filestation.py
+++ b/src/filestation/synology_filestation.py
@@ -38,10 +38,69 @@ class SynologyFileStation:
             headers["X-SYNO-TOKEN"] = self.syno_token
         return headers
 
+    def _relogin_and_refresh(self) -> bool:
+        """Re-authenticate via the SynologyAuth registered for this base_url.
+
+        On success, refreshes this instance's `_sid` / X-SYNO-TOKEN and returns
+        True. Returns False when no auth is registered (e.g. standalone use) or
+        the relogin fails, in which case the caller keeps the original error.
+
+        Import is deferred to runtime to avoid a circular import
+        (auth -> filestation).
+        """
+        try:
+            from auth.synology_auth import get_auth_for_url
+        except ImportError:
+            return False
+        auth = get_auth_for_url(self.base_url)
+        if auth is None or not auth.relogin():
+            return False
+        self.session_id = auth.current_session_id
+        self.syno_token = auth.current_syno_token
+        return True
+
     def _make_request(
         self, api: str, version: str, method: str, use_post: bool = False, **params
     ) -> Dict[str, Any]:
-        """Make a request to Synology API."""
+        """Make a request to Synology API.
+
+        Recovers transparently from DSM error 119 ("SID not found") — returned
+        once the server-side session dies (idle expiry, or a DSM reboot which
+        drops every session). FileStation keeps its own SID, so it needs the
+        same single-retry re-auth that SynologyAPIClient performs; otherwise the
+        SID stays dead until the process is restarted.
+        """
+        data = self._send(api, version, method, use_post, params)
+
+        if not data.get("success") and data.get("error", {}).get("code") == 119:
+            if self._relogin_and_refresh():
+                data = self._send(api, version, method, use_post, params)
+
+        if not data.get("success"):
+            error_code = data.get("error", {}).get("code", "unknown")
+            error_info = data.get("error", {})
+
+            # Include detailed error information if available
+            error_message = f"Synology API error: {error_code}"
+
+            # Check for detailed errors array as mentioned in documentation
+            if "errors" in error_info and error_info["errors"]:
+                detailed_errors = []
+                for err in error_info["errors"]:
+                    err_detail = f"Code {err.get('code', 'unknown')}"
+                    if "path" in err:
+                        err_detail += f" for path: {err['path']}"
+                    detailed_errors.append(err_detail)
+                error_message += f" - Details: {'; '.join(detailed_errors)}"
+
+            raise Exception(error_message)
+
+        return data.get("data", {})
+
+    def _send(
+        self, api: str, version: str, method: str, use_post: bool, params: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Internal: perform the HTTP call and return the parsed body, no retry."""
         request_params = {
             "api": api,
             "version": version,
@@ -68,27 +127,7 @@ class SynologyFileStation:
             )
         response.raise_for_status()
 
-        data = response.json()
-        if not data.get("success"):
-            error_code = data.get("error", {}).get("code", "unknown")
-            error_info = data.get("error", {})
-
-            # Include detailed error information if available
-            error_message = f"Synology API error: {error_code}"
-
-            # Check for detailed errors array as mentioned in documentation
-            if "errors" in error_info and error_info["errors"]:
-                detailed_errors = []
-                for err in error_info["errors"]:
-                    err_detail = f"Code {err.get('code', 'unknown')}"
-                    if "path" in err:
-                        err_detail += f" for path: {err['path']}"
-                    detailed_errors.append(err_detail)
-                error_message += f" - Details: {'; '.join(detailed_errors)}"
-
-            raise Exception(error_message)
-
-        return data.get("data", {})
+        return response.json()
 
     def _make_upload_request(
         self, api: str, version: str, method: str, files: Dict[str, Any], **params


### PR DESCRIPTION
# Extend DSM 119 auto-recovery to FileStation

Follow-up to #27, which added the single-retry re-auth on error 119 but scoped it to
`SynologyAPIClient` and explicitly left FileStation as future work. This finishes the job.

## Why it's still needed after #27

`SynologyFileStation` keeps its **own** `_sid` and issues requests through its **own**
`_make_request()`, so it never went through the patched client. A 119 was raised straight
to the caller as `Exception("Synology API error: 119")`, and the dead SID was reused
forever — the only cure remained a process restart.

I hit this in production in a way that makes the split very visible. My NAS rebooted for a
DSM update (7.3.2 Update 4), which destroys **every** server-side session:

| Code path | Behaviour after the reboot |
| --- | --- |
| `SYNO.Core.*` via `SynologyAPIClient` (#27) | ✅ silent re-auth, `synology_system_info` kept working |
| FileStation (own SID, own `_make_request`) | ❌ every tool stuck on 119 until `docker restart` |

Because the Core tools self-healed, the server *looked* alive while all file operations
were dead — which reads to the user as "the MCP server keeps crashing", even though the
container never crashed (`RestartCount=0`).

## What this PR does

- Adds `_relogin_and_refresh()`, reusing the `_AUTH_REGISTRY` / `get_auth_for_url()`
  lookup introduced in #27 — no constructor signature changes, same design as before.
- Splits the HTTP call out into `_send()`. Its body is the previous `_make_request()`
  body, unchanged, minus the error handling.
- `_make_request()` now detects code 119, re-authenticates, and replays the call
  **exactly once**, then falls through to the original error-handling block untouched
  (same message format, same `errors[]` detail expansion).

All 15 FileStation operations inherit the recovery, since they all go through
`_make_request()`.

## Deliberately out of scope: uploads

`_make_upload_request()` and the chunked upload path are **not** patched. Their multipart
payloads wrap file streams that have already been consumed by the first attempt, so a
blind replay risks sending truncated content. Retrying those safely needs stream rewinding
(or re-opening the file), which is a bigger change than this one should carry.

## Behaviour

| Scenario | Before | After |
| --- | --- | --- |
| FileStation call, live session | ✅ works | ✅ works (unchanged) |
| FileStation call after session expiry / DSM reboot | ❌ 119 forever, needs restart | ✅ re-auth + retry, caller sees success |
| Relogin fails (bad credentials, NAS down) | n/a | Original 119 exception is raised, unchanged |
| No `SynologyAuth` registered (standalone use, tests) | n/a | Original 119 exception, no retry loop |
| After an explicit `auth.logout()` | unchanged | unchanged — logout clears the cached credentials, so no silent re-auth |

## Tested with

DSM 7.3.2-86009 Update 4 on a DS224+, HTTP/SSE deployment.

Rather than wait hours for a natural expiry, I forced the exact failure by poisoning the
in-memory SID (no destructive action on the NAS) and letting the code recover:

```
1. login          : OK
2. SID valide     : 14 partages
3. SID mort       : RECUPERE -> 14 partages     # got 119, relogged in, replayed
4. SID rafraichi  : True
```

Also verified that the refactor preserved behaviour: `requests.post`/`requests.get` calls,
`raise Exception(error_message)` and the `errors[]` detail expansion are all still present
and reached, and the 15 `_make_request()` call sites are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when FileStation sessions expire during standard requests.
  * Requests now automatically re-authenticate and retry once when session credentials become invalid.
  * Enhanced error handling and diagnostics for authentication and API failures.
  * Upload requests avoid unsafe retries when a file stream may already be in use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->