### PR TITLE
fix: make the test suite runnable on Windows

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -93,7 +93,28 @@ class SynologyConfig:
 
         Returns True if permissions are safe, False otherwise.
         Prints warning if permissions are too open.
+
+        POSIX only. On Windows os.getuid() does not exist and st_mode carries
+        no meaningful group/other bits, so this check raised AttributeError and
+        took the whole settings load down with it.
+
+        On Windows the check is SKIPPED and this returns True so the settings
+        file still loads. Be clear about what that means: True here means
+        "not checked", not "verified safe". Windows access control lives in
+        ACLs, which this function cannot read. The alternative -- returning
+        False -- would make secrets.json unusable on Windows entirely, which is
+        a worse outcome than an unverified file, but it does mean a
+        world-readable secrets.json will load without complaint. The warning
+        below is deliberately not debug-level so the gap is visible in logs.
         """
+        if not hasattr(os, "getuid"):
+            logger.warning(
+                f"Permission check for {path} SKIPPED: this platform has no POSIX "
+                "file ownership. Treated as acceptable so the file still loads, but its "
+                "permissions were NOT verified. Confirm the ACLs restrict it to your user."
+            )
+            return True
+
         try:
             file_stat = path.stat()
             mode = file_stat.st_mode

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,28 @@ from pathlib import Path
 
 import pytest
 
+# This file prints emoji in its session banners. On a console using a legacy
+# codepage (Windows cp1252 is the common case) that raises UnicodeEncodeError
+# inside pytest_sessionstart, which pytest reports as INTERNALERROR and which
+# aborts the whole run before a single test executes -- a decorative banner
+# taking down the suite. Reconfiguring sys.stdout at import time does not help,
+# because pytest replaces the stream with its own capture object afterwards, so
+# encode defensively at each call instead.
+_builtin_print = print
+
+
+def print(*args, **kwargs):  # noqa: A001 - deliberately shadowing within conftest
+    """print() that degrades unencodable characters instead of raising."""
+    try:
+        _builtin_print(*args, **kwargs)
+    except UnicodeEncodeError:
+        encoding = getattr(sys.stdout, "encoding", None) or "ascii"
+        safe = [
+            str(a).encode(encoding, errors="replace").decode(encoding, errors="replace")
+            for a in args
+        ]
+        _builtin_print(*safe, **kwargs)
+
 # Add src directory to Python path
 src_path = Path(__file__).parent.parent / "src"
 sys.path.insert(0, str(src_path))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,8 +29,20 @@ def _safe_print(*args, **kwargs):
     and falsey explicit streams correctly — pre-sanitises before the first
     write to avoid a partial-write-then-retry cycle.
     """
-    output = kwargs.get("file") or sys.stdout
-    encoding = getattr(output, "encoding", None) or "ascii"
+    # Only treat an absent or explicitly-None file= as the default stream; a
+    # falsey explicit stream (encoding attribute or __bool__ both exist) is
+    # still a valid destination and must not be replaced by sys.stdout.
+    if "file" in kwargs and kwargs["file"] is not None:
+        output = kwargs["file"]
+    else:
+        output = sys.stdout
+
+    encoding = getattr(output, "encoding", None)
+    if encoding is None:
+        # An encoding-less stream (e.g. io.StringIO) accepts Unicode directly,
+        # so bypass codec sanitization rather than corrupting text to ASCII.
+        _builtin_print(*args, **kwargs)
+        return
 
     def _safe(val):
         return str(val).encode(encoding, errors="replace").decode(encoding, errors="replace")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,16 +23,25 @@ _builtin_print = builtins.print
 
 
 def _safe_print(*args, **kwargs):
-    """print() that degrades unencodable characters instead of raising."""
-    try:
-        _builtin_print(*args, **kwargs)
-    except UnicodeEncodeError:
-        encoding = getattr(sys.stdout, "encoding", None) or "ascii"
-        safe = [
-            str(a).encode(encoding, errors="replace").decode(encoding, errors="replace")
-            for a in args
-        ]
-        _builtin_print(*safe, **kwargs)
+    """print() that degrades unencodable characters instead of raising.
+
+    Handles explicit ``file=`` destinations, string-valued ``sep``/``end``,
+    and falsey explicit streams correctly — pre-sanitises before the first
+    write to avoid a partial-write-then-retry cycle.
+    """
+    output = kwargs.get("file") or sys.stdout
+    encoding = getattr(output, "encoding", None) or "ascii"
+
+    def _safe(val):
+        return str(val).encode(encoding, errors="replace").decode(encoding, errors="replace")
+
+    safe_args = [_safe(a) for a in args]
+    safe_kwargs = dict(kwargs)
+    for key in ("sep", "end"):
+        val = safe_kwargs.get(key)
+        if isinstance(val, str):
+            safe_kwargs[key] = _safe(val)
+    _builtin_print(*safe_args, **safe_kwargs)
 
 
 builtins.print = _safe_print

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ def print(*args, **kwargs):  # noqa: A001 - deliberately shadowing within confte
         ]
         _builtin_print(*safe, **kwargs)
 
+
 # Add src directory to Python path
 src_path = Path(__file__).parent.parent / "src"
 sys.path.insert(0, str(src_path))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,21 +1,28 @@
 """Pytest configuration for real Synology Download Station testing."""
 
+import builtins
 import sys
 from pathlib import Path
 
 import pytest
 
-# This file prints emoji in its session banners. On a console using a legacy
-# codepage (Windows cp1252 is the common case) that raises UnicodeEncodeError
-# inside pytest_sessionstart, which pytest reports as INTERNALERROR and which
-# aborts the whole run before a single test executes -- a decorative banner
+# This suite prints emoji in its session banners and in many test modules. On a
+# console using a legacy codepage (Windows cp1252 is the common case) that
+# raises UnicodeEncodeError, which pytest reports as INTERNALERROR and which
+# aborts the whole run before a single test executes -- decorative output
 # taking down the suite. Reconfiguring sys.stdout at import time does not help,
-# because pytest replaces the stream with its own capture object afterwards, so
-# encode defensively at each call instead.
-_builtin_print = print
+# because pytest replaces the stream with its own capture object afterwards.
+#
+# Shadowing `print` inside conftest alone is not enough: each test module is a
+# separate module namespace, so `tests/test_nfs.py` etc. still resolve the
+# built-in function and hit the same cp1252 stream (pytest.ini enables `-s`).
+# Replacing `builtins.print` globally makes every module -- conftest and all
+# collected tests -- use the encoding-safe shim. Encode defensively at each
+# call instead of once at import time.
+_builtin_print = builtins.print
 
 
-def print(*args, **kwargs):  # noqa: A001 - deliberately shadowing within conftest
+def _safe_print(*args, **kwargs):
     """print() that degrades unencodable characters instead of raising."""
     try:
         _builtin_print(*args, **kwargs)
@@ -26,6 +33,9 @@ def print(*args, **kwargs):  # noqa: A001 - deliberately shadowing within confte
             for a in args
         ]
         _builtin_print(*safe, **kwargs)
+
+
+builtins.print = _safe_print
 
 
 # Add src directory to Python path

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,22 @@ def reload_config():
         del sys.modules[mod]
 
 
+# Variables Windows needs in order to resolve a home directory. Clearing the
+# whole environment breaks Path("~").expanduser() on Windows -- POSIX falls back
+# to the pwd database, Windows has nothing to fall back to and raises
+# RuntimeError("Could not determine home directory"), which failed 9 tests here
+# for reasons unrelated to what they assert. Keep these; none of them influence
+# any SYNOLOGY_* lookup under test.
+_HOME_VARS = ("USERPROFILE", "HOMEDRIVE", "HOMEPATH", "HOME", "SYSTEMROOT", "SystemRoot")
+
+
+def clear_env(**overrides):
+    """patch.dict(os.environ, ..., clear=True) that still leaves a home directory."""
+    preserved = {k: os.environ[k] for k in _HOME_VARS if k in os.environ}
+    preserved.update(overrides)
+    return patch.dict(os.environ, preserved, clear=True)
+
+
 class TestSynologyConfig:
     """Test Synology configuration loading and validation."""
 
@@ -45,7 +61,7 @@ class TestSynologyConfig:
         """Test default configuration values."""
         reload_config()
 
-        with patch.dict(os.environ, {}, clear=True):
+        with clear_env():
             with patch("config.SETTINGS_FILE", Path("/nonexistent/secrets.json")):
                 with patch.object(Path, "exists", return_value=False):
                     from config import SynologyConfig
@@ -77,7 +93,7 @@ class TestSynologyConfig:
 
         reload_config()
 
-        with patch.dict(os.environ, {}, clear=True):
+        with clear_env():
             with patch("config.SETTINGS_FILE", secrets_file):
                 from config import SynologyConfig
 
@@ -102,7 +118,7 @@ class TestSynologyConfig:
 
         reload_config()
 
-        with patch.dict(os.environ, {}, clear=True):
+        with clear_env():
             with patch("config.SETTINGS_FILE", secrets_file):
                 from config import SynologyConfig
 
@@ -132,7 +148,7 @@ class TestSynologyConfig:
 
         reload_config()
 
-        with patch.dict(os.environ, {}, clear=True):
+        with clear_env():
             with patch("config.SETTINGS_FILE", secrets_file):
                 from config import SynologyConfig
 
@@ -150,7 +166,7 @@ class TestSynologyConfig:
         # load_dotenv(".env") at construction time, which re-injects whatever
         # is in the developer's local .env. Patch os.path.exists so the loader
         # treats the project as having no .env.
-        with patch.dict(os.environ, {}, clear=True):
+        with clear_env():
             with patch("config.SETTINGS_FILE", Path("/nonexistent/secrets.json")):
                 with patch("config.os.path.exists", return_value=False):
                     with patch.object(Path, "exists", return_value=False):
@@ -202,7 +218,7 @@ class TestSynologyConfig:
 
         reload_config()
 
-        with patch.dict(os.environ, {}, clear=True):
+        with clear_env():
             with patch("config.SETTINGS_FILE", secrets_file):
                 from config import SynologyConfig
 
@@ -221,7 +237,7 @@ class TestSynologyConfig:
 
         reload_config()
 
-        with patch.dict(os.environ, {}, clear=True):
+        with clear_env():
             with patch("config.SETTINGS_FILE", secrets_file):
                 from config import SynologyConfig
 
@@ -249,7 +265,7 @@ class TestSynologyConfig:
 
         reload_config()
 
-        with patch.dict(os.environ, {}, clear=True):
+        with clear_env():
             with patch("config.SETTINGS_FILE", secrets_file):
                 from config import SynologyConfig
 
@@ -279,7 +295,7 @@ class TestFilePermissions:
 
         reload_config()
 
-        with patch.dict(os.environ, {}, clear=True):
+        with clear_env():
             with patch("config.SETTINGS_FILE", secrets_file):
                 from config import SynologyConfig
 


### PR DESCRIPTION
On a default Windows console the suite currently cannot run at all — pytest aborts with `INTERNALERROR` before executing a single test. Forcing UTF-8 gets past that but leaves 9 failures. Three independent causes, all Windows-only.

### 1. conftest emoji kills the run

`conftest.py` prints emoji in its session banners. On a legacy codepage (cp1252 is the Windows default) that raises `UnicodeEncodeError` inside `pytest_sessionstart`, which pytest surfaces as `INTERNALERROR` and which aborts the entire session — a decorative banner taking down the suite.

Reconfiguring `sys.stdout` at import time does **not** fix it: pytest replaces the stream with its own capture object afterwards. So conftest now encodes defensively at each print and degrades unencodable characters rather than raising.

### 2. Clearing the environment removes the home directory

Nine config tests use `patch.dict(os.environ, {}, clear=True)`. That drops `USERPROFILE`, and `Path("~").expanduser()` then raises `RuntimeError: Could not determine home directory` on Windows — POSIX falls back to the `pwd` database, Windows has nothing to fall back to.

A `clear_env()` helper preserves only the home-directory variables. None of them affect any `SYNOLOGY_*` lookup under test, so the assertions are unchanged.

### 3. `os.getuid()` in production code

`_check_file_permissions` calls `os.getuid()`, which does not exist on Windows, so loading a settings file raises `AttributeError` and takes the whole settings load with it. This one is not test-only.

**Please look closely at this trade-off.** The check is now skipped where POSIX ownership is unavailable and returns `True` so the file still loads. To be explicit: `True` there means *not checked*, not *verified safe*. Windows permissions live in ACLs this function cannot read, so an over-permissive settings file will load without complaint. Returning `False` instead would make `settings.json` unusable on Windows entirely, which seemed the worse trade — but it is your call, and I am happy to flip it to fail-closed, or to gate it behind a config flag, if you would rather.

The skip logs at `warning` level so the gap is visible rather than silent.

### Result

| | Windows, default console | Windows, `PYTHONUTF8=1` |
|---|---|---|
| before | `INTERNALERROR`, 0 tests run | 9 failed, 77 passed, 40 skipped |
| after | 86 passed, 40 skipped | 86 passed, 40 skipped |

No behavior change on POSIX: every change is guarded by a platform check or preserves existing values.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Settings loading now works on Windows even when POSIX-style file permission checks are unavailable.
  - A warning is shown when file permissions cannot be verified on Windows.

- **Tests**
  - Improved test output handling for characters unsupported by the console encoding.
  - Updated configuration tests to preserve Windows home-directory settings while isolating environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->