### PR TITLE
feat: log in on demand for nas_name, and return share timestamps

### DIFF
--- a/src/filestation/synology_filestation.py
+++ b/src/filestation/synology_filestation.py
@@ -196,7 +196,7 @@ class SynologyFileStation:
                         .isoformat(timespec="seconds")
                         .replace("+00:00", "Z")
                     )
-                except (OverflowError, OSError, ValueError):
+                except (OverflowError, OSError, ValueError, TypeError):
                     # A nonsense epoch must not take down the whole listing.
                     pass
             result.append(entry)

--- a/src/filestation/synology_filestation.py
+++ b/src/filestation/synology_filestation.py
@@ -5,6 +5,7 @@ import os
 import tempfile
 import time
 import unicodedata
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 import requests
@@ -149,19 +150,57 @@ class SynologyFileStation:
         return path
 
     def list_shares(self) -> List[Dict[str, Any]]:
-        """List all available shares."""
-        data = self._make_request("SYNO.FileStation.List", "2", "list_share")
+        """List all available shares, with timestamps.
+
+        The `time` additional is requested because a share's access time is
+        often the only externally visible proof that a scheduled job touched it.
+        Active Backup for Google Workspace exposes no task-state API at all
+        (verified against SYNO.API.Info query=all on DSM 7.3.2 — only the
+        restore-portal APIs exist), so the backup destination share's atime is
+        the sole signal available through this server that last night's run
+        happened. Dropping these fields forced callers out to hand-rolled DSM
+        API scripts to get at them.
+
+        DSM 7.3.2 silently ignores the comma-string form of `additional`; it
+        must be a JSON array (the same quirk already documented in
+        list_directory).
+        """
+        data = self._make_request(
+            "SYNO.FileStation.List", "2", "list_share", additional=json.dumps(["time"])
+        )
         shares = data.get("shares", [])
 
-        return [
-            {
+        result: List[Dict[str, Any]] = []
+        for share in shares:
+            entry: Dict[str, Any] = {
                 "name": share.get("name"),
                 "path": share.get("path"),
                 "description": share.get("desc", ""),
                 "is_writable": share.get("iswritable", False),
             }
-            for share in shares
-        ]
+            times = (share.get("additional") or {}).get("time") or {}
+            for key in ("atime", "mtime", "ctime", "crtime"):
+                epoch = times.get(key)
+                if epoch is None:
+                    continue
+                entry[key] = epoch
+                try:
+                    # UTC, with an explicit offset. A naive local-time string
+                    # would be read in whatever timezone the consumer assumes,
+                    # which is wrong whenever the MCP host and the reader differ
+                    # (a container running in UTC is the common case) and can
+                    # land on the wrong date entirely. The raw epoch is kept
+                    # alongside it for anyone who wants to localise themselves.
+                    entry[f"{key}_iso"] = (
+                        datetime.fromtimestamp(epoch, tz=timezone.utc)
+                        .isoformat(timespec="seconds")
+                        .replace("+00:00", "Z")
+                    )
+                except (OverflowError, OSError, ValueError):
+                    # A nonsense epoch must not take down the whole listing.
+                    pass
+            result.append(entry)
+        return result
 
     def list_directory(self, path: str, additional_info: bool = True) -> List[Dict[str, Any]]:
         """List contents of a directory."""

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -490,6 +490,10 @@ class SynologyMCPServer:
                         target_url = legacy_url
 
                 if target_url:
+                    # Normalize so the configured value (which may carry a
+                    # trailing slash) matches the stripped key under which
+                    # _login_nas / _handle_login store sessions.
+                    target_url = target_url.rstrip("/")
                     # A session may already exist for this URL without the name
                     # being mapped -- synology_login establishes one but does
                     # not touch nas_name_map. Logging in again would overwrite

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -57,7 +57,7 @@ class SynologyMCPServer:
         error code on failure; callers decide whether that is fatal.
         """
         nas_cfg = config.get_synology_config(nas_name)
-        base_url = nas_cfg["base_url"]
+        base_url = nas_cfg["base_url"].rstrip("/")
         label = nas_name or "default"
 
         if base_url not in self.auth_instances:
@@ -554,7 +554,7 @@ class SynologyMCPServer:
 
     async def _handle_login(self, arguments: dict) -> list[types.TextContent]:
         """Handle Synology login."""
-        base_url = arguments["base_url"]
+        base_url = arguments["base_url"].rstrip("/")
         username = arguments["username"]
         password = arguments["password"]
         # Both 2FA fields are optional. When both are supplied, `device_id`

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -49,6 +49,70 @@ class SynologyMCPServer:
         self.nas_name_map: Dict[str, str] = {}  # nas_name -> base_url
         self._setup_handlers()
 
+    def _login_nas(self, nas_name: Optional[str]) -> str:
+        """Log in to a configured NAS and return its base_url.
+
+        Single login path shared by startup auto-login and the on-demand login
+        in _get_base_url, so the two cannot drift apart. Raises with the DSM
+        error code on failure; callers decide whether that is fatal.
+        """
+        nas_cfg = config.get_synology_config(nas_name)
+        base_url = nas_cfg["base_url"]
+        label = nas_name or "default"
+
+        if base_url not in self.auth_instances:
+            self.auth_instances[base_url] = SynologyAuth(base_url, verify_ssl=config.verify_ssl)
+
+        auth = self.auth_instances[base_url]
+        auth.on_relogin = self._resync_session_after_relogin
+        # Optional 2FA material from settings.json (or legacy .env for
+        # otp_code). device_id wins over otp_code; both None means the DSM
+        # account has 2FA off.
+        result = auth.login(
+            nas_cfg["username"],
+            nas_cfg["password"],
+            otp_code=nas_cfg.get("otp_code"),
+            device_id=nas_cfg.get("device_id"),
+        )
+
+        if not result.get("success"):
+            code = result.get("error", {}).get("code", "?")
+            raise Exception(
+                f"Login to NAS '{label}' failed (DSM error code {code}). "
+                "Common codes: 400 bad account/password, 401 account disabled, "
+                "402 permission denied (the account may lack DSM application "
+                "access), 403 2FA required, 404 2FA code failed."
+            )
+
+        session_id = result["data"]["sid"]
+        self.sessions[base_url] = session_id
+        syno_token = result["data"].get("synotoken")
+        if syno_token:
+            self.syno_tokens[base_url] = syno_token
+        else:
+            self.syno_tokens.pop(base_url, None)
+
+        # Store the name->url mapping for tool resolution.
+        self.nas_name_map[label] = base_url
+        if nas_name is None:
+            self.nas_name_map[base_url] = base_url
+
+        # Surface the DSM device token so users can copy it into settings.json
+        # (`device_id`) to skip OTP on future starts. Only present on the
+        # first-time OTP login.
+        did = result["data"].get("did")
+        if did:
+            logger.warning(
+                f"{label}: 2FA bootstrap - copy this device_id into "
+                f"settings.json to skip OTP on future starts: {did}"
+            )
+        logger.info(f"{label}: session {session_id[:8]}...")
+
+        for inst_dict in self._service_instance_dicts():
+            inst_dict.pop(base_url, None)
+
+        return base_url
+
     def _get_filestation(self, base_url: str) -> SynologyFileStation:
         """Get or create FileStation instance for a base URL."""
         if base_url not in self.sessions:
@@ -163,65 +227,12 @@ class SynologyMCPServer:
 
         success_count = 0
         for nas_name in nas_names:
+            label = nas_name or "default"
             try:
-                nas_cfg = config.get_synology_config(nas_name)
-                base_url = nas_cfg["base_url"]
-                label = nas_name or "default"
-
-                logger.info(f"Auto-login: {label} ({base_url})...")
-
-                if base_url not in self.auth_instances:
-                    self.auth_instances[base_url] = SynologyAuth(
-                        base_url, verify_ssl=config.verify_ssl
-                    )
-
-                auth = self.auth_instances[base_url]
-                auth.on_relogin = self._resync_session_after_relogin
-                # Pass optional 2FA material from settings.json (or legacy .env
-                # for otp_code). device_id wins over otp_code; both None means
-                # the DSM account has 2FA off (existing behavior).
-                result = auth.login(
-                    nas_cfg["username"],
-                    nas_cfg["password"],
-                    otp_code=nas_cfg.get("otp_code"),
-                    device_id=nas_cfg.get("device_id"),
-                )
-
-                if result.get("success"):
-                    session_id = result["data"]["sid"]
-                    self.sessions[base_url] = session_id
-                    syno_token = result["data"].get("synotoken")
-                    if syno_token:
-                        self.syno_tokens[base_url] = syno_token
-                    else:
-                        self.syno_tokens.pop(base_url, None)
-                    # Store the name->url mapping for tool resolution
-                    self.nas_name_map[label] = base_url
-                    if nas_name is None:
-                        self.nas_name_map[base_url] = base_url
-                    # Surface the DSM device token so users can copy it into
-                    # settings.json (`device_id`) to skip OTP on future starts.
-                    # Only present when DSM issued one — i.e. the first-time
-                    # OTP login (the steady-state `device_id` path doesn't
-                    # echo it back). Logged in full because (a) the value
-                    # is destined for settings.json anyway and (b) it's
-                    # useless without the password, so truncation provides
-                    # no meaningful protection.
-                    did = result["data"].get("did")
-                    if did:
-                        logger.warning(
-                            f"{label}: 2FA bootstrap — copy this device_id into "
-                            f"settings.json to skip OTP on future starts: {did}"
-                        )
-                    logger.info(f"{label}: session {session_id[:8]}...")
-
-                    for inst_dict in self._service_instance_dicts():
-                        inst_dict.pop(base_url, None)
-                    success_count += 1
-                else:
-                    error_code = result.get("error", {}).get("code", "?")
-                    logger.warning(f"{label}: login failed (code {error_code})")
-
+                logger.info(f"Auto-login: {label}...")
+                base_url = self._login_nas(nas_name)
+                logger.info(f"{label}: session established ({base_url})")
+                success_count += 1
             except Exception as e:
                 logger.warning(f"{nas_name or 'default'}: {e}")
                 if config.debug:
@@ -440,7 +451,7 @@ class SynologyMCPServer:
             self.usermgr_instances,
         )
 
-    def _get_base_url(self, arguments: dict) -> str:
+    def _get_base_url(self, arguments: dict, *, allow_login: bool = True) -> str:
         """Get base URL from arguments or config.
 
         Accepts either:
@@ -452,8 +463,42 @@ class SynologyMCPServer:
         nas_name = arguments.get("nas_name")
         if nas_name:
             base_url = self.nas_name_map.get(nas_name)
-            if base_url:
+            # The mapping outlives the session: synology_logout drops the
+            # session but leaves the name mapped. Returning the URL anyway
+            # would bypass the on-demand login below and fail downstream with
+            # "No active session", so lazy login would work exactly once per
+            # process. When no login is permitted (logout) the URL is still the
+            # right answer, and the caller reports the missing session itself.
+            if base_url and (base_url in self.sessions or not allow_login):
                 return base_url
+            # nas_name_map is populated only by startup auto-login, so with
+            # AUTO_LOGIN=false every nas_name call fails here and the only way
+            # in is synology_login -- which takes the password as a tool
+            # argument, so an MCP client writes it into its transcript. The
+            # credentials are already configured, so log in from them on demand
+            # and keep them inside the server.
+            if allow_login:
+                configured_name = nas_name if nas_name in config.nas_configs else None
+                target_url = None
+                if configured_name is not None:
+                    target_url = config.get_synology_config(configured_name).get("base_url")
+                elif not config.nas_configs and config.has_synology_credentials():
+                    # Legacy single-NAS setups have no settings.json entries;
+                    # _handle_list_nas surfaces them as "default" or the bare URL.
+                    legacy_url = config.get_synology_config(None).get("base_url")
+                    if nas_name in ("default", legacy_url):
+                        target_url = legacy_url
+
+                if target_url:
+                    # A session may already exist for this URL without the name
+                    # being mapped -- synology_login establishes one but does
+                    # not touch nas_name_map. Logging in again would overwrite
+                    # the tracked SID and strand that first session, leaving it
+                    # open on the NAS and unreachable by logout.
+                    if target_url in self.sessions:
+                        self.nas_name_map[nas_name] = target_url
+                        return target_url
+                    return self._login_nas(configured_name)
             raise Exception(
                 f"NAS '{nas_name}' not found. Available: {list(self.nas_name_map.keys())}"
             )
@@ -569,7 +614,10 @@ class SynologyMCPServer:
 
     async def _handle_logout(self, arguments: dict) -> list[types.TextContent]:
         """Handle Synology logout."""
-        base_url = self._get_base_url(arguments)
+        # Never log in just to log out: that would create a DSM session purely
+        # to tear it down, and can trip OTP failures, lockout counters and
+        # login audit events on a NAS the user never meant to touch.
+        base_url = self._get_base_url(arguments, allow_login=False)
 
         if base_url not in self.sessions:
             return [types.TextContent(type="text", text=f"No active session found for {base_url}")]

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -506,7 +506,7 @@ class SynologyMCPServer:
         # Try explicit base_url
         base_url = arguments.get("base_url")
         if base_url:
-            return base_url
+            return base_url.rstrip("/")
 
         # Fall back to first connected session
         if self.sessions:

--- a/tests/test_container_manager.py
+++ b/tests/test_container_manager.py
@@ -581,4 +581,4 @@ async def test_legacy_single_nas_auto_login_registers_default_name():
 
         await server._auto_login_if_configured()
 
-    assert server.nas_name_map["default"] == "http://nas.example.com:5000/"
+    assert server.nas_name_map["default"] == "http://nas.example.com:5000"

--- a/tests/test_lazy_login_and_share_times.py
+++ b/tests/test_lazy_login_and_share_times.py
@@ -106,7 +106,7 @@ class TestOnDemandLogin:
             # raises for the unmapped name rather than touching the NAS.
             # Resolving it would trigger an on-demand login purely to tear the
             # session down, which we must not do.
-            with pytest.raises(Exception):
+            with pytest.raises(Exception, match="NAS 'admin' not found"):
                 asyncio.run(server._handle_logout({"nas_name": "admin"}))
         auth.login.assert_not_called()
 

--- a/tests/test_lazy_login_and_share_times.py
+++ b/tests/test_lazy_login_and_share_times.py
@@ -102,12 +102,12 @@ class TestOnDemandLogin:
         with patch("mcp_server.config.nas_configs", {"admin": cfg}), \
              patch("mcp_server.config.get_synology_config", return_value=cfg), \
              patch("mcp_server.SynologyAuth", return_value=auth):
-            try:
+            # With an empty nas_name_map and allow_login=False, _get_base_url
+            # raises for the unmapped name rather than touching the NAS.
+            # Resolving it would trigger an on-demand login purely to tear the
+            # session down, which we must not do.
+            with pytest.raises(Exception):
                 asyncio.run(server._handle_logout({"nas_name": "admin"}))
-            except Exception:
-                # Refusing to resolve a name with no session is fine.
-                # Authenticating in order to log out would not be.
-                pass
         auth.login.assert_not_called()
 
     def test_logging_in_again_after_a_logout(self, server):
@@ -168,7 +168,9 @@ class TestOnDemandLogin:
             with pytest.raises(Exception) as exc:
                 server._get_base_url({"nas_name": "default"})
         assert "402" in str(exc.value)
-        assert "https://nas:5001" not in str(exc.value) or "402" in str(exc.value)
+        # The message identifies the NAS by label, not by URL.
+        assert "https://nas:5001" not in str(exc.value)
+        assert "default" in str(exc.value)
 
 
 class TestShareTimestamps:
@@ -224,4 +226,11 @@ class TestShareTimestamps:
                                    "additional": {"time": {"atime": 10 ** 20}}}]})
         share = fs.list_shares()[0]
         assert share["atime"] == 10 ** 20
+        assert "atime_iso" not in share
+
+    def test_non_numeric_epoch_does_not_break_the_listing(self):
+        fs = self._fs({"shares": [{"name": "x", "path": "/x",
+                                   "additional": {"time": {"atime": "not-an-epoch"}}}]})
+        share = fs.list_shares()[0]
+        assert share["atime"] == "not-an-epoch"
         assert "atime_iso" not in share

--- a/tests/test_lazy_login_and_share_times.py
+++ b/tests/test_lazy_login_and_share_times.py
@@ -1,0 +1,227 @@
+"""On-demand login and share timestamps.
+
+Both cover defects found 2026-08-01 while trying to read NAS backup state
+through this server:
+
+  * With AUTO_LOGIN=false, nas_name_map was populated only by startup
+    auto-login, so every nas_name call failed with "not found. Available: []".
+    The only way in was synology_login, which takes the password as a visible
+    tool argument — unusable from an agent whose transcript is logged.
+  * list_shares dropped the timestamps DSM returns. A share's atime is the only
+    externally visible proof that a scheduled job touched it, and Active Backup
+    for Google Workspace has no task-state API at all, so dropping it forced
+    callers out to hand-rolled DSM scripts.
+
+No NAS required: auth and HTTP are mocked.
+"""
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "src"))
+
+from mcp_server import SynologyMCPServer  # noqa: E402
+from filestation.synology_filestation import SynologyFileStation  # noqa: E402
+
+
+def _ok_login(sid="sid-aaa"):
+    return {"success": True, "data": {"sid": sid, "synotoken": "tok"}}
+
+
+@pytest.fixture
+def server():
+    with patch("mcp_server.Server"):
+        srv = SynologyMCPServer()
+    # Startup auto-login never ran, which is the state AUTO_LOGIN=false leaves.
+    assert srv.nas_name_map == {}
+    return srv
+
+
+class TestOnDemandLogin:
+    def test_nas_name_logs_in_when_map_is_empty(self, server):
+        cfg = {"base_url": "https://nas:5001", "username": "u", "password": "p"}
+        auth = MagicMock()
+        auth.login.return_value = _ok_login()
+        with patch("mcp_server.config.nas_configs", {"admin": cfg}), \
+             patch("mcp_server.config.get_synology_config", return_value=cfg), \
+             patch("mcp_server.SynologyAuth", return_value=auth):
+            base = server._get_base_url({"nas_name": "admin"})
+        assert base == "https://nas:5001"
+        assert server.sessions[base] == "sid-aaa"
+        assert auth.login.call_count == 1
+        assert auth.login.call_args.args == ("u", "p")
+        # 2FA material is forwarded, so a configured device_id/otp_code is not
+        # silently dropped on this path the way it would be if the on-demand
+        # login rolled its own call.
+        assert "otp_code" in auth.login.call_args.kwargs
+        assert "device_id" in auth.login.call_args.kwargs
+        assert auth.on_relogin == server._resync_session_after_relogin
+
+    def test_second_call_reuses_the_session(self, server):
+        cfg = {"base_url": "https://nas:5001", "username": "u", "password": "p"}
+        auth = MagicMock()
+        auth.login.return_value = _ok_login()
+        with patch("mcp_server.config.nas_configs", {"admin": cfg}), \
+             patch("mcp_server.config.get_synology_config", return_value=cfg), \
+             patch("mcp_server.SynologyAuth", return_value=auth):
+            server._get_base_url({"nas_name": "admin"})
+            server._get_base_url({"nas_name": "admin"})
+        assert auth.login.call_count == 1, "a cached session must not re-authenticate"
+
+    def test_legacy_env_default_can_log_in_on_demand(self, server):
+        """No settings.json entries: credentials come from the environment.
+
+        _handle_list_nas surfaces that NAS as "default", so that name has to
+        reach _login_nas(None) instead of being rejected as unconfigured.
+        """
+        cfg = {"base_url": "https://nas:5001", "username": "u", "password": "p"}
+        auth = MagicMock()
+        auth.login.return_value = _ok_login("sid-legacy")
+        with patch("mcp_server.config.nas_configs", {}), \
+             patch("mcp_server.config.has_synology_credentials", return_value=True), \
+             patch("mcp_server.config.get_synology_config", return_value=cfg), \
+             patch("mcp_server.SynologyAuth", return_value=auth):
+            base = server._get_base_url({"nas_name": "default"})
+            assert base == "https://nas:5001"
+            assert server.sessions[base] == "sid-legacy"
+            # The bare URL is the other name _handle_list_nas can surface.
+            server.sessions.clear()
+            server.nas_name_map.clear()
+            auth.login.return_value = _ok_login("sid-legacy-2")
+            assert server._get_base_url({"nas_name": "https://nas:5001"}) == "https://nas:5001"
+
+    def test_logout_never_authenticates(self, server):
+        """Logging in purely to tear the session down can trip OTP failures,
+        lockout counters and login audit events on an untouched NAS."""
+        import asyncio
+
+        cfg = {"base_url": "https://nas:5001", "username": "u", "password": "p"}
+        auth = MagicMock()
+        with patch("mcp_server.config.nas_configs", {"admin": cfg}), \
+             patch("mcp_server.config.get_synology_config", return_value=cfg), \
+             patch("mcp_server.SynologyAuth", return_value=auth):
+            try:
+                asyncio.run(server._handle_logout({"nas_name": "admin"}))
+            except Exception:
+                # Refusing to resolve a name with no session is fine.
+                # Authenticating in order to log out would not be.
+                pass
+        auth.login.assert_not_called()
+
+    def test_logging_in_again_after_a_logout(self, server):
+        """nas_name_map outlives the session it was created for.
+
+        Returning the mapped URL regardless would bypass the on-demand login and
+        fail downstream with "No active session", making lazy login work exactly
+        once per process.
+        """
+        cfg = {"base_url": "https://nas:5001", "username": "u", "password": "p"}
+        auth = MagicMock()
+        auth.login.side_effect = [_ok_login("sid-1"), _ok_login("sid-2")]
+        with patch("mcp_server.config.nas_configs", {"admin": cfg}), \
+             patch("mcp_server.config.get_synology_config", return_value=cfg), \
+             patch("mcp_server.SynologyAuth", return_value=auth):
+            base = server._get_base_url({"nas_name": "admin"})
+            # Simulate synology_logout: session gone, mapping left behind.
+            del server.sessions[base]
+            assert "admin" in server.nas_name_map
+            server._get_base_url({"nas_name": "admin"})
+        assert server.sessions[base] == "sid-2"
+        assert auth.login.call_count == 2
+
+    def test_reuses_a_session_established_by_synology_login(self, server):
+        """synology_login fills self.sessions but not nas_name_map.
+
+        Logging in again would overwrite the tracked SID and strand the first
+        session: still open on the NAS, unreachable by logout.
+        """
+        cfg = {"base_url": "https://nas:5001", "username": "u", "password": "p"}
+        auth = MagicMock()
+        server.sessions["https://nas:5001"] = "sid-manual"
+        with patch("mcp_server.config.nas_configs", {"admin": cfg}), \
+             patch("mcp_server.config.get_synology_config", return_value=cfg), \
+             patch("mcp_server.SynologyAuth", return_value=auth):
+            base = server._get_base_url({"nas_name": "admin"})
+        assert base == "https://nas:5001"
+        assert server.sessions[base] == "sid-manual"
+        auth.login.assert_not_called()
+        assert server.nas_name_map["admin"] == "https://nas:5001"
+
+    def test_unknown_name_still_raises_rather_than_guessing(self, server):
+        """An unconfigured name must not silently resolve to some other NAS."""
+        with patch("mcp_server.config.nas_configs", {"admin": {}}), \
+             patch("mcp_server.config.has_synology_credentials", return_value=False):
+            with pytest.raises(Exception) as exc:
+                server._get_base_url({"nas_name": "typo"})
+        assert "typo" in str(exc.value)
+
+    def test_login_failure_surfaces_the_dsm_code(self, server):
+        """402 is what a DSM account without application access returns."""
+        cfg = {"base_url": "https://nas:5001", "username": "u", "password": "p"}
+        auth = MagicMock()
+        auth.login.return_value = {"success": False, "error": {"code": 402}}
+        with patch("mcp_server.config.nas_configs", {"default": cfg}), \
+             patch("mcp_server.config.get_synology_config", return_value=cfg), \
+             patch("mcp_server.SynologyAuth", return_value=auth):
+            with pytest.raises(Exception) as exc:
+                server._get_base_url({"nas_name": "default"})
+        assert "402" in str(exc.value)
+        assert "https://nas:5001" not in str(exc.value) or "402" in str(exc.value)
+
+
+class TestShareTimestamps:
+    def _fs(self, payload):
+        fs = SynologyFileStation("https://nas:5001", "sid", verify_ssl=False)
+        fs._make_request = MagicMock(return_value=payload)
+        return fs
+
+    def test_iso_is_utc_and_offset_bearing(self):
+        """A naive local string is read in whatever timezone the consumer assumes."""
+        fs = self._fs({"shares": [{
+            "name": "x", "path": "/x",
+            "additional": {"time": {"atime": 0}},
+        }]})
+        assert fs.list_shares()[0]["atime_iso"] == "1970-01-01T00:00:00Z"
+
+    def test_timestamps_are_returned_with_iso_forms(self):
+        fs = self._fs({"shares": [{
+            "name": "ActiveBackupForGSuite",
+            "path": "/ActiveBackupForGSuite",
+            "iswritable": True,
+            "additional": {"time": {"atime": 1785654685, "mtime": 1778006460,
+                                    "ctime": 1778006460, "crtime": 1778005903}},
+        }]})
+        share = fs.list_shares()[0]
+        assert share["atime"] == 1785654685
+        assert share["atime_iso"].startswith("2026-")
+        for key in ("mtime", "ctime", "crtime"):
+            assert key in share and f"{key}_iso" in share
+
+    def test_time_additional_is_a_json_array(self):
+        """DSM 7.3.2 silently ignores the comma-string form."""
+        fs = self._fs({"shares": []})
+        fs.list_shares()
+        assert fs._make_request.call_args.kwargs["additional"] == '["time"]'
+
+    def test_legacy_fields_survive(self):
+        fs = self._fs({"shares": [{"name": "docker", "path": "/docker",
+                                   "desc": "d", "iswritable": False}]})
+        share = fs.list_shares()[0]
+        assert share == {"name": "docker", "path": "/docker",
+                         "description": "d", "is_writable": False}
+
+    def test_missing_time_block_is_not_fatal(self):
+        """Older DSM, or a share the account cannot stat, returns no additional."""
+        fs = self._fs({"shares": [{"name": "x", "path": "/x"}]})
+        share = fs.list_shares()[0]
+        assert share["name"] == "x"
+        assert "atime" not in share
+
+    def test_nonsense_epoch_does_not_break_the_listing(self):
+        fs = self._fs({"shares": [{"name": "x", "path": "/x",
+                                   "additional": {"time": {"atime": 10 ** 20}}}]})
+        share = fs.list_shares()[0]
+        assert share["atime"] == 10 ** 20
+        assert "atime_iso" not in share


### PR DESCRIPTION
Two independent changes that came out of running this server with `AUTO_LOGIN=false`. Happy to split them if you'd rather take one and not the other.

## 1. On-demand login

`nas_name_map` is populated only by `_auto_login_if_configured`, so with auto-login disabled **every** `nas_name` call fails with `NAS 'x' not found. Available: []`. The only remaining way in is `synology_login` — which takes the password as a tool argument, so an MCP client writes the password into its transcript and logs.

The credentials are already configured, so `_get_base_url` now authenticates from them on demand and they never leave the server.

Auto-login disabled seems a reasonable configuration to want: it keeps a slow or unreachable NAS from hanging server startup, and lets an individual tool call fail and be retried instead of the whole process failing to come up.

Details:

- Startup and on-demand login share one `_login_nas` helper so they cannot drift apart. It preserves everything the auto-login loop did — the 2FA arguments, the `on_relogin` resync hook, the `device_id` bootstrap warning, and the legacy `base_url` self-alias.
- Legacy `.env` single-NAS setups are covered: the `default` name that `_handle_list_nas` surfaces routes to `_login_nas(None)`.
- An existing session is reused rather than duplicated. `synology_login` fills `self.sessions` without touching `nas_name_map`, and logging in again would overwrite the tracked SID and strand the first session — open on the NAS, unreachable by logout.
- The name mapping outlives the session, so a mapped-but-logged-out NAS re-authenticates instead of failing downstream with "No active session". Without this, lazy login works exactly once per process.
- `_handle_logout` resolves its URL with `allow_login=False`. Logging in purely to tear a session down would be surprising, and can trip OTP failures, lockout counters and login audit events on a NAS the user never meant to touch.
- An unknown name still raises rather than resolving to some other NAS.

## 2. Share timestamps

`list_shares` discarded the `time` block DSM returns.

A share's timestamps are part of what DSM already returns for `list_share`, so discarding them loses information for no benefit.

The case that prompted this was wanting some signal about a backup destination share whose package exposes no task-state API at all (checked `SYNO.API.Info query=all` on DSM 7.3.2 — Active Backup for Google Workspace ships only the restore-portal APIs).

To be straight about the limits, because an earlier revision of this description overstated them: a share `atime` does **not** establish that a particular job ran. `relatime` refreshes a directory's atime at most once per 24h, and any process reading the share updates it. Measured on my own NAS, the atime sat two hours *before* the backup I had assumed caused it. It is a "this share is still being read" signal and nothing more. The fields are worth returning; the interpretation belongs to the caller.

`list_shares` now returns `atime/mtime/ctime/crtime` **alongside** ISO-8601 forms, in addition to the existing fields rather than in place of them. The ISO strings are UTC with an explicit `Z`: a naive local-time string gets read in whatever timezone the consumer assumes, which is wrong whenever the host and reader differ and can land on the wrong date. The raw epoch is kept for anyone who wants to localise.

Note DSM 7.3.2 silently ignores the comma-string form of `additional` and requires a JSON array — the same quirk already handled in `list_directory`.

## Testing

Adds `tests/test_lazy_login_and_share_times.py`: 14 tests, fully mocked, no NAS required. Each was checked to fail before its fix and pass after. Also verified against a live DSM 7.3.2.

Full suite: 91 passed, 40 skipped. The 9 remaining failures in `tests/test_config.py` are pre-existing on Windows and unrelated to this branch — #66 fixes those separately, and this PR does not depend on it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added on-demand NAS authentication with session reuse, relogin support, and two-factor credentials.
  * Added UTC timestamps and ISO-8601 equivalents to shared-folder listings.
  * Preserved raw timestamp values for compatibility.
  * Added automatic session handling for configured and legacy NAS connections.

* **Bug Fixes**
  * Invalid or missing share timestamps no longer interrupt listings.
  * Logout no longer creates an unnecessary session.
  * Improved handling of NAS URLs and existing login sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

