### PR TITLE
feat: add native Streamable HTTP transport

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,12 @@ RUN apt-get update && apt-get install -y \
 # Copy requirements first for better caching
 COPY requirements.txt requirements-http.txt ./
 
-# Install Python dependencies. The default image (stdio / Xiaozhi) installs only
-# requirements.txt. The HTTP/SSE image (docker-compose.http.yml) passes
-# INSTALL_HTTP=true to additionally install mcp-proxy from requirements-http.txt.
+# Install Python dependencies. mcp>=2.0.0 ships starlette, uvicorn, and
+# sse-starlette, so the same requirements.txt covers both stdio and Streamable
+# HTTP transports. The INSTALL_HTTP arg is kept for backward compatibility with
+# docker-compose.http.yml's build args, but is now a no-op.
 ARG INSTALL_HTTP=false
-RUN pip install --no-cache-dir -r requirements.txt \
-    && if [ "$INSTALL_HTTP" = "true" ] || [ "$INSTALL_HTTP" = "1" ]; then \
-        pip install --no-cache-dir -r requirements-http.txt; \
-    fi
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy source code
 COPY src/ ./src/

--- a/docker-compose.http.yml
+++ b/docker-compose.http.yml
@@ -1,58 +1,41 @@
-# Alternative deployment for HTTP/SSE transport
+# Alternative deployment for Streamable HTTP transport
 #
-# This compose file exposes the Synology MCP server over HTTP/SSE using
-# mcp-proxy (https://github.com/sparfenyuk/mcp-proxy) so it can be consumed
-# as a *remote* MCP server by clients that support URL-based connectors
-# (Claude Desktop "Custom connectors", Claude.ai web, Cursor, etc.).
+# This compose file exposes the Synology MCP server over native Streamable HTTP
+# (MCP 2.0) using uvicorn, so it can be consumed as a *remote* MCP server by
+# clients that support URL-based connectors (Claude Desktop custom connectors,
+# Claude.ai web, Cursor, etc.).
 #
-# The stdio mode in the main docker-compose.yml stays unchanged; use this
-# file when you want a long-running, network-accessible MCP server.
-#
-# Prerequisites:
-#   - The HTTP image installs mcp-proxy from requirements-http.txt via the
-#     INSTALL_HTTP=true build arg below (it is NOT in the default image).
-#   - A reverse proxy in front (DSM, Nginx, Traefik, Caddy...) terminating
-#     TLS, since most MCP clients only accept HTTPS endpoints.
+# The stdio mode in the main docker-compose.yml stays unchanged; use this file
+# when you want a long-running, network-accessible MCP server.
 #
 # Usage:
 #   1. Edit the environment block below with your credentials (or use settings.json)
 #   2. docker compose -f docker-compose.http.yml up -d --build
 #   3. Point your reverse proxy at http://127.0.0.1:8765
 #   4. In your MCP client, add a custom connector:
-#        URL: https://your-domain.example.com/sse
+#        URL: https://your-domain.example.com/mcp
 #
 # Security note:
-#   mcp-proxy does NOT provide server-side authentication. The port below is
-#   published on 127.0.0.1 only, so it is reachable solely from a reverse proxy
-#   on this host (DSM/Nginx/etc.) — never directly from the LAN/internet. Keep
-#   that reverse proxy adding authentication (Basic Auth, mTLS, OAuth2 proxy,
-#   IP allow-list). A reverse proxy running in another container should reach
-#   this service over the Docker network rather than the published port.
+#   The server binds to 127.0.0.1 only, so it is reachable solely from a
+#   reverse proxy on this host (DSM/Nginx/etc.) — never directly from the
+#   LAN/internet. Keep that reverse proxy adding authentication (Basic Auth,
+#   mTLS, OAuth2 proxy, IP allow-list). A reverse proxy running in another
+#   container should reach this service over the Docker network rather than
+#   the published port.
 
 services:
   synology-mcp-http:
-    build:
-      context: .
-      # Install the HTTP/SSE transport deps (mcp-proxy) into this image only.
-      args:
-        INSTALL_HTTP: "true"
+    build: .
     container_name: synology-mcp-http
-    # mcp-proxy spawns `python main.py` as a stdio child and exposes it
-    # over SSE/Streamable HTTP on port 8765.
+    # Native Streamable HTTP via uvicorn (no mcp-proxy needed)
     command:
-      - "mcp-proxy"
-      - "--host=0.0.0.0"
-      - "--port=8765"
-      - "--pass-environment"
-      - "--allow-origin=*"
-      - "--"
       - "python"
       - "main.py"
-    ports:
-      # Publish on loopback only — a same-host reverse proxy (DSM/Nginx) reaches
-      # it; the unauthenticated proxy is never directly exposed to the network.
-      - "127.0.0.1:8765:8765"
     environment:
+      - MCP_HTTP=true
+      - MCP_HTTP_HOST=0.0.0.0
+      - MCP_HTTP_PORT=8765
+      - MCP_HTTP_PATH=/mcp
       - XDG_CONFIG_HOME=/home/mcpuser/.config
       # Required: Synology NAS connection
       - SYNOLOGY_URL=https://your-nas.example.com:5001
@@ -66,6 +49,10 @@ services:
       - DEBUG=false
       - LOG_LEVEL=INFO
       - ENABLE_XIAOZHI=false
+    ports:
+      # Publish on loopback only — a same-host reverse proxy (DSM/Nginx) reaches
+      # it; the unauthenticated server is never directly exposed to the network.
+      - "127.0.0.1:8765:8765"
     volumes:
       - ./logs:/app/logs
       # Multi-NAS settings.json support (XDG path) — optional

--- a/main.py
+++ b/main.py
@@ -80,8 +80,11 @@ if __name__ == "__main__":
     if enable_xiaozhi:
         logger.info("Starting Synology MCP Server with Xiaozhi Bridge")
         logger.info("Supports BOTH Xiaozhi and Claude/Cursor simultaneously")
+    elif config.http_enabled:
+        logger.info(f"Starting Synology MCP Server over Streamable HTTP")
+        logger.info(f"HTTP endpoint: http://{config.http_host}:{config.http_port}{config.http_path}")
     else:
-        logger.info("Starting Synology MCP Server")
+        logger.info("Starting Synology MCP Server over stdio")
         logger.info("Claude/Cursor only mode")
 
     # Check requirements

--- a/requirements-http.txt
+++ b/requirements-http.txt
@@ -1,7 +1,6 @@
-# HTTP/SSE transport dependencies — used only by docker-compose.http.yml.
-# These are NOT installed in the default stdio/Xiaozhi image; the Dockerfile
-# installs them only when built with INSTALL_HTTP=true.
+# HTTP transport dependencies — used only by docker-compose.http.yml.
 #
-# Upper bound: mcp-proxy is young and pre-1.0, so pin below the next major to
-# avoid a breaking change silently breaking HTTP deployments.
-mcp-proxy>=0.12.0,<1.0
+# mcp>=2.0.0 already pulls in starlette, uvicorn, and sse-starlette, so this
+# file is now empty by design. It exists so the Dockerfile's INSTALL_HTTP build
+# arg keeps working (the `pip install -r requirements-http.txt` step becomes a
+# no-op). If you add HTTP-only dependencies in the future, put them here.

--- a/src/config.py
+++ b/src/config.py
@@ -78,6 +78,12 @@ class SynologyConfig:
         self.debug = os.getenv("DEBUG", "false").lower() == "true"
         self.log_level = os.getenv("LOG_LEVEL", "INFO").upper()
 
+        # Streamable HTTP transport settings
+        self.http_enabled = os.getenv("MCP_HTTP", "false").lower() == "true"
+        self.http_host = os.getenv("MCP_HTTP_HOST", "127.0.0.1")
+        self.http_port = int(os.getenv("MCP_HTTP_PORT", "8765"))
+        self.http_path = os.getenv("MCP_HTTP_PATH", "/mcp")
+
         # Legacy single-NAS env vars (still supported as fallback)
         self.synology_url = os.getenv("SYNOLOGY_URL")
         self.synology_username = os.getenv("SYNOLOGY_USERNAME")
@@ -122,6 +128,10 @@ class SynologyConfig:
         self.xiaozhi_enabled = False
         self.xiaozhi_token = ""
         self.xiaozhi_endpoint = "wss://api.xiaozhi.me/mcp/"
+        self.http_enabled = False
+        self.http_host = "127.0.0.1"
+        self.http_port = 8765
+        self.http_path = "/mcp"
 
         if SETTINGS_FILE.exists():
             # Check file permissions - refuse to load if insecure
@@ -210,6 +220,16 @@ class SynologyConfig:
                         self.debug = server_section["debug"]
                     if "log_level" in server_section:
                         self.log_level = server_section["log_level"].upper()
+                    # HTTP transport settings
+                    http_section = server_section.get("http", {})
+                    if "enabled" in http_section:
+                        self.http_enabled = http_section["enabled"]
+                    if "host" in http_section:
+                        self.http_host = http_section["host"]
+                    if "port" in http_section:
+                        self.http_port = http_section["port"]
+                    if "path" in http_section:
+                        self.http_path = http_section["path"]
 
             except json.JSONDecodeError as e:
                 logger.error(f"Failed to parse {SETTINGS_FILE}: {e}")

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -2677,8 +2677,75 @@ class SynologyMCPServer:
                 ),
             )
 
+    async def run_http(self):
+        """Run the MCP server over Streamable HTTP (MCP 2.0 native).
+
+        Serves the same Synology tools over HTTP so remote MCP clients can
+        connect via a URL (Claude Desktop custom connectors, Claude.ai web,
+        Cursor, etc.) without requiring stdio/SSH access.
+        """
+        # Validate configuration first
+        config_errors = config.validate_config()
+        if config_errors and config.auto_login:
+            error_msg = f"Configuration errors: {', '.join(config_errors)}"
+            logger.error(error_msg)
+            raise Exception(f"Invalid configuration - stopping server. {error_msg}")
+        elif config.debug:
+            logger.debug(f"Configuration loaded: {config}")
+
+        # Attempt auto-login if configured (this will raise exception on failure and stop server)
+        logger.info("Attempting auto-login...")
+        await self._auto_login_if_configured()
+
+        try:
+            import uvicorn
+
+            app = self.server.streamable_http_app(
+                streamable_http_path=config.http_path,
+                host=config.http_host,
+            )
+            logger.info(
+                f"Starting Streamable HTTP MCP server on http://{config.http_host}:{config.http_port}{config.http_path}"
+            )
+            server = uvicorn.Server(
+                uvicorn.Config(
+                    app,
+                    host=config.http_host,
+                    port=config.http_port,
+                    log_level="info" if config.debug else "warning",
+                )
+            )
+            await server.serve()
+        except KeyboardInterrupt:
+            logger.info("Received shutdown signal, cleaning up sessions...")
+        except Exception as e:
+            logger.error(f"Server runtime error: {e}")
+            if config.debug:
+                logger.debug("Traceback:", exc_info=True)
+            raise
+        finally:
+            # Always attempt session cleanup on shutdown
+            if self.sessions:
+                logger.info("Cleaning up active sessions...")
+                cleanup_results = await self.cleanup_sessions()
+
+                if cleanup_results:
+                    logger.info("Session cleanup summary:")
+                    for result in cleanup_results:
+                        logger.info(f"  {result}")
+
+                logger.info("Session cleanup completed")
+            else:
+                logger.info("No active sessions to clean up")
+
     async def run(self):
-        """Run the MCP server."""
+        """Run the MCP server over the configured transport."""
+        if config.http_enabled:
+            return await self.run_http()
+        return await self.run_stdio()
+
+    async def run_stdio(self):
+        """Run the MCP server over stdio (default)."""
         # Validate configuration first
         config_errors = config.validate_config()
         if config_errors and config.auto_login:


### PR DESCRIPTION
Migrate from mcp-proxy to native MCP 2.0 Streamable HTTP.

**What changed:**
- Add `http_enabled` / `http_host` / `http_port` / `http_path` config (env `MCP_HTTP*`, or `server.http` in settings.json)
- Add `SynologyMCPServer.run_http()` using `Server.streamable_http_app()` + uvicorn; `run()` dispatches to HTTP when enabled
- `docker-compose.http.yml` now runs `main.py` directly (no mcp-proxy)
- Drop `mcp-proxy`; mcp>=2.0.0 already ships starlette/uvicorn/sse-starlette
- Dockerfile `INSTALL_HTTP` arg is now a no-op

**Notable:** relies on the cleanup in PR #69 (legacy v1 API removal).