### PR TITLE
fix: prefer API v6 for the first-time 2FA bootstrap

### DIFF
--- a/src/auth/synology_auth.py
+++ b/src/auth/synology_auth.py
@@ -102,6 +102,15 @@ class SynologyAuth:
         # Try common API versions (start with newer versions)
         api_versions = ["7", "6", "3", "2"]
 
+        # Exception: the first-time 2FA bootstrap. Observed on DSM 7.3.2, a v7
+        # login with `enable_device_token=yes` succeeds but returns no `did`,
+        # so no trusted-device token is ever issued and every later start falls
+        # back to "OTP required" (403). v6 returns the token for the same
+        # request. Only reorder for the bootstrap; steady-state logins keep
+        # preferring v7.
+        if otp_code and not device_id:
+            api_versions = ["6", "7", "3", "2"]
+
         for version in api_versions:
             payload = {
                 "api": "SYNO.API.Auth",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -320,6 +320,8 @@ def test_login_with_otp_code_adds_otp_and_device_token_request(monkeypatch):
 
     assert len(calls) == 1
     params = calls[0]["params"]
+    # Bootstrap prefers v6: v7 succeeds but returns no `did` on DSM 7.x.
+    assert params["version"] == "6"
     assert params["otp_code"] == "123456"
     assert params["enable_device_token"] == "yes"
     # Device-id path must NOT be taken when we're sending an OTP.
@@ -340,6 +342,8 @@ def test_login_with_device_id_trusted_device_path(monkeypatch):
 
     assert len(calls) == 1
     params = calls[0]["params"]
+    # Steady-state logins keep preferring v7; only the OTP bootstrap reorders.
+    assert params["version"] == "7"
     assert params["device_id"] == "DID_abc"
     assert "otp_code" not in params
     assert "enable_device_token" not in params


### PR DESCRIPTION
### Problem

Login tries API versions newest-first, `["7", "6", "3", "2"]`. On DSM 7.x, a **v7** login with `enable_device_token=yes` *succeeds* — `success: true`, a valid session — but the response carries **no `did`**. No trusted-device token is ever issued, so every later start falls back to requiring an OTP (403), and there is nothing to persist or copy.

The identical request against **v6** returns the token.

Because v7 succeeds, there is no error to fall through on: the loop stops at the first working version and never reaches v6.

### Fix

Reorders to `["6", "7", "3", "2"]` for the bootstrap case only — an OTP present with no `device_id` yet:

```python
if otp_code and not device_id:
    api_versions = ["6", "7", "3", "2"]
```

Steady-state logins are untouched and still prefer v7. This changes the version used for the one-off bootstrap and nothing else.

### Testing

`pytest tests/` — 96 passed, 40 skipped, identical to `main` on the same machine. Verified against DSM 7.4.1-90080, where a v7 bootstrap returns no `did` and the v6 bootstrap returns one that then authenticates subsequent restarts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OTP authentication when no device token is provided by trying the compatible login method first.
  * Preserved existing authentication behavior for other login flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->