### PR TITLE
fix: support a NAS behind a reverse proxy via an explicit url key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Per-NAS `url` key in `settings.json`: when present it is used verbatim (trailing slash stripped) and wins over `host`/`port`, so a NAS published through a reverse proxy on the default 443 — whose URL carries no port — can finally be addressed. Non-string values are rejected with a warning and skip only that entry. (#76)
+
 ### Fixed
 - `list_directory` and `get_file_info` reported **every file as 0 bytes**. DSM returns the byte count inside the entry's `additional` block (which is where we ask for the `size` field), but both handlers only read a top-level `size` key that DSM never populates. Sizes are now read from `additional.size`, falling back to the top-level key for API versions that inline it.
 - `search_files` always failed with `Synology API error: 103` ("no such method"). It polled `SYNO.FileStation.Search`'s `status` method, which does not exist on DSM 7.3.2 — the `list` method reports completion via its own `finished` flag. Polling now goes through `list`, and cleanup calls `clean` as well as `stop` to release the task slot.

--- a/README.md
+++ b/README.md
@@ -543,6 +543,12 @@ The docker-compose.yml automatically mounts your `~/.config/synology-mcp` direct
       "username": "admin",
       "password": "your_password",
       "note": "Backup NAS"
+    },
+    "nas3": {
+      "url": "https://nas.example.com",
+      "username": "admin",
+      "password": "your_password",
+      "note": "NAS behind a reverse proxy"
     }
   },
   "xiaozhi": {
@@ -563,16 +569,20 @@ The docker-compose.yml automatically mounts your `~/.config/synology-mcp` direct
 **Configuration fields:**
 | Field | Required | Description |
 |-------|----------|-------------|
-| `host` | Yes | NAS hostname or IP address |
+| `host` | Yes* | NAS hostname or IP address |
 | `port` | No | API port (default: 5000 for HTTP, 5001 for HTTPS) |
+| `url` | Yes* | Full base URL (e.g., `https://nas.example.com`); wins over `host`/`port` — use for a NAS behind a reverse proxy |
 | `username` | Yes | NAS username |
 | `password` | Yes | NAS password |
 | `otp_code` | No | One-shot 6-digit 2FA code (first login only, then remove) |
 | `device_id` | No | Long-lived trusted-device token from DSM (`did`); skip OTP on all future logins |
 | `note` | No | Optional description for your reference |
 
+*Either `host` or `url` is required per NAS entry.
+
 **Notes:**
 - The server will use port 5001 (HTTPS) if port is 5001, otherwise defaults to HTTP (5000)
+- The `host`/`port` form always appends a port and derives the scheme from it, so it cannot express `https://nas.example.com` on the default 443 — set `url` directly for reverse-proxied setups
 - File permissions: `chmod 600 ~/.config/synology-mcp/settings.json` is required for security
 - The server will refuse to load settings if permissions are too open
 - Both .env and settings.json can be used together (settings.json takes priority)

--- a/src/config.py
+++ b/src/config.py
@@ -166,6 +166,19 @@ class SynologyConfig:
                         )
                         continue
 
+                    # `url` wins over host/port when present. The host/port form
+                    # below can only ever build https://host:5001 or http://host:<port>,
+                    # so it cannot address a NAS sitting behind a reverse proxy on
+                    # the default 443 (no port in the URL at all). Reverse-proxied
+                    # setups set `url` directly.
+                    raw_url = nas_info.get("url")
+                    if raw_url is not None and not isinstance(raw_url, str):
+                        logger.warning(
+                            f"Invalid 'url' for NAS '{nas_name}' - expected string, "
+                            f"got {type(raw_url)}"
+                        )
+                        continue
+                    explicit_url = (raw_url or "").rstrip("/")
                     host = nas_info.get("host", "")
                     port = nas_info.get("port", 5000)
                     username = nas_info.get("username", "")
@@ -182,8 +195,10 @@ class SynologyConfig:
                     otp_code = nas_info.get("otp_code") or None
                     device_id = nas_info.get("device_id") or None
 
-                    if not host:
-                        logger.warning(f"Missing 'host' for NAS '{nas_name}' in {SETTINGS_FILE}")
+                    if not host and not explicit_url:
+                        logger.warning(
+                            f"Missing 'host' (or 'url') for NAS '{nas_name}' in {SETTINGS_FILE}"
+                        )
                         continue
                     if not username:
                         logger.warning(
@@ -196,8 +211,11 @@ class SynologyConfig:
                         )
                         continue
 
-                    scheme = "https" if port == 5001 else "http"
-                    base_url = f"{scheme}://{host}:{port}"
+                    if explicit_url:
+                        base_url = explicit_url
+                    else:
+                        scheme = "https" if port == 5001 else "http"
+                        base_url = f"{scheme}://{host}:{port}"
 
                     self.nas_configs[nas_name] = {
                         "base_url": base_url,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -278,6 +278,113 @@ class TestSynologyConfig:
                 url = cfg.resolve_base_url("nonexistent")
                 assert url is None
 
+    def test_explicit_url_overrides_host_port(self, tmp_path):
+        """Test that an explicit url wins over host/port (reverse-proxy setups)."""
+        secrets_data = {
+            "synology": {
+                "proxied": {
+                    "url": "https://nas.example.com/",
+                    "host": "ignored.example.com",
+                    "port": 5000,
+                    "username": "admin",
+                    "password": "pass123",
+                }
+            }
+        }
+
+        secrets_file = tmp_path / "secrets.json"
+        secrets_file.write_text(json.dumps(secrets_data))
+        os.chmod(str(secrets_file), 0o600)  # config refuses insecure-perm files
+
+        reload_config()
+
+        with clear_env():
+            with patch("config.SETTINGS_FILE", secrets_file):
+                from config import SynologyConfig
+
+                cfg = SynologyConfig()
+
+                # url is used verbatim (trailing slash stripped); host/port ignored
+                assert cfg.nas_configs["proxied"]["base_url"] == "https://nas.example.com"
+
+    def test_non_string_url_entry_skipped(self, tmp_path, caplog):
+        """Test that a non-string url skips just that entry, not the whole file."""
+        import logging
+
+        secrets_data = {
+            "synology": {
+                "bad": {"url": 123, "username": "a", "password": "b"},
+                "good": {"host": "192.168.1.1", "port": 5000, "username": "a", "password": "b"},
+            }
+        }
+
+        secrets_file = tmp_path / "secrets.json"
+        secrets_file.write_text(json.dumps(secrets_data))
+        os.chmod(str(secrets_file), 0o600)  # config refuses insecure-perm files
+
+        reload_config()
+
+        with clear_env():
+            with patch("config.SETTINGS_FILE", secrets_file):
+                from config import SynologyConfig
+
+                with caplog.at_level(logging.WARNING, logger="synology-mcp"):
+                    cfg = SynologyConfig()
+
+                assert "bad" not in cfg.nas_configs
+                assert "good" in cfg.nas_configs
+                assert any("Invalid 'url'" in rec.message for rec in caplog.records)
+
+    def test_empty_url_falls_back_to_host_port(self, tmp_path):
+        """Test that an empty url is ignored and host/port builds the base URL."""
+        secrets_data = {
+            "synology": {
+                "nas": {
+                    "url": "",
+                    "host": "192.168.1.5",
+                    "port": 5001,
+                    "username": "a",
+                    "password": "b",
+                }
+            }
+        }
+
+        secrets_file = tmp_path / "secrets.json"
+        secrets_file.write_text(json.dumps(secrets_data))
+        os.chmod(str(secrets_file), 0o600)  # config refuses insecure-perm files
+
+        reload_config()
+
+        with clear_env():
+            with patch("config.SETTINGS_FILE", secrets_file):
+                from config import SynologyConfig
+
+                cfg = SynologyConfig()
+
+                assert cfg.nas_configs["nas"]["base_url"] == "https://192.168.1.5:5001"
+
+    def test_missing_host_and_url_skipped(self, tmp_path, caplog):
+        """Test that an entry with neither host nor url is skipped with a warning."""
+        import logging
+
+        secrets_data = {"synology": {"noaddr": {"username": "a", "password": "b"}}}
+
+        secrets_file = tmp_path / "secrets.json"
+        secrets_file.write_text(json.dumps(secrets_data))
+        os.chmod(str(secrets_file), 0o600)  # config refuses insecure-perm files
+
+        reload_config()
+
+        with clear_env():
+            with patch("config.SETTINGS_FILE", secrets_file):
+                from config import SynologyConfig
+
+                with caplog.at_level(logging.WARNING, logger="synology-mcp"):
+                    cfg = SynologyConfig()
+
+                assert "noaddr" not in cfg.nas_configs
+                assert any("Missing 'host' (or 'url')" in rec.message for rec in caplog.records)
+
 
 class TestFilePermissions:
     """Test file permission checking."""


### PR DESCRIPTION
### Problem

`SynologyConfig` derives the base URL as:

```python
scheme = "https" if port == 5001 else "http"
base_url = f"{scheme}://{host}:{port}"
```

The port is always appended and the scheme is inferred solely from it. A NAS published through a reverse proxy on the default 443 therefore cannot be addressed at all: its URL carries no port, and `https` does not follow from `port == 5001`.

There is no combination of `host`/`port` that produces `https://nas.example.com`.

### Fix

Adds an optional per-NAS `url` key. When present it is used verbatim and wins over `host`/`port`:

```json
{ "synology": { "myNas": { "url": "https://nas.example.com", "username": "...", "password": "..." } } }
```

`host`/`port` behaviour is untouched when `url` is absent, so existing `settings.json` files are unaffected. The "missing host" validation now accepts either form.

Non-string `url` values are rejected with a warning, matching the existing `isinstance(nas_info, dict)` check above. Without that guard `.rstrip()` would raise `AttributeError` out of `_load_settings`, which catches only `JSONDecodeError` and `OSError` — so a single bad value would abort loading for every NAS entry.

### Scope change since first push

This PR originally also made `verify_ssl` a per-NAS setting. The review correctly found that incomplete: the per-NAS value reached `SynologyAuth` but not the six service clients, so a NAS could verify at login and not verify on subsequent API calls. It also fell back to a `self.verify_ssl` that is still the environment value at that point, because `server.verify_ssl` is parsed later in `_load_settings`.

Both are real, and fixing them properly means touching every client construction site. I have dropped `verify_ssl` from this PR entirely so the reverse-proxy fix can stand on its own, and will follow up with a separate PR that resolves SSL policy per `base_url` and threads it through all sites. This PR is now a single file and changes nothing about SSL behaviour.

### Testing

`pytest tests/` — 96 passed, 40 skipped, identical to `main` on the same machine. Verified against DSM 7.4.1-90080 behind a reverse proxy on 443 with a real certificate, and that a malformed `url` now skips just that entry while the remaining entries load.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring each NAS with a complete URL, including reverse-proxied endpoints.
  * Full URLs take precedence over host and port settings, while host/port configuration remains supported as a fallback.
  * URLs are normalized by removing trailing slashes.

* **Bug Fixes**
  * Invalid or incomplete NAS entries are now safely rejected with appropriate warnings.

* **Documentation**
  * Updated configuration guidance and changelog details for per-NAS URL support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->