### PR TITLE
fix: persist the 2FA trusted-device token so it survives a restart

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -558,13 +558,16 @@ class SynologyConfig:
         file, and clears any spent `otp_code` alongside it. Returns True on a
         successful write.
         """
-        if not device_id or not SETTINGS_FILE.exists():
+        if not isinstance(device_id, str) or not device_id.strip():
+            return False
+        if not SETTINGS_FILE.exists():
             return False
 
         try:
             data = json.loads(SETTINGS_FILE.read_text())
-            entry = data.get("synology", {}).get(nas_name)
-            if entry is None:
+            synology = data.get("synology") if isinstance(data, dict) else None
+            entry = synology.get(nas_name) if isinstance(synology, dict) else None
+            if not isinstance(entry, dict):
                 logger.warning(f"Cannot persist device_id: NAS '{nas_name}' not in settings")
                 return False
             token_changed = entry.get("device_id") != device_id

--- a/src/config.py
+++ b/src/config.py
@@ -545,6 +545,55 @@ class SynologyConfig:
             "device_id": None,
         }
 
+    def save_device_id(self, nas_name: str, device_id: str) -> bool:
+        """Persist a DSM trusted-device token back to settings.json.
+
+        DSM can hand back a fresh `did` on a login that already presented one.
+        The old token stops working at that point, so a token kept only in
+        memory survives exactly one process. MCP servers are restarted every
+        session, which turns that into "2FA works once, then 403 forever".
+
+        Rewrites only this NAS's `device_id`, preserving everything else in the
+        file, and clears any spent `otp_code` alongside it. Returns True on a
+        successful write.
+        """
+        if not device_id or not SETTINGS_FILE.exists():
+            return False
+
+        try:
+            data = json.loads(SETTINGS_FILE.read_text())
+            entry = data.get("synology", {}).get(nas_name)
+            if entry is None:
+                logger.warning(f"Cannot persist device_id: NAS '{nas_name}' not in settings")
+                return False
+            if entry.get("device_id") == device_id:
+                return False  # unchanged, nothing to write
+
+            entry["device_id"] = device_id
+            # A one-shot OTP is spent once DSM has issued a device token.
+            # Leaving it behind makes the next start look like a first-time
+            # 2FA login and fail on a stale code.
+            entry.pop("otp_code", None)
+
+            # Write via a 0600 temp file in the same directory, then rename, so
+            # the secrets never briefly exist world-readable and a crash
+            # mid-write cannot truncate the real file.
+            tmp = SETTINGS_FILE.with_suffix(".json.tmp")
+            tmp.write_text(json.dumps(data, indent=2) + "\n")
+            os.chmod(tmp, 0o600)
+            os.replace(tmp, SETTINGS_FILE)
+
+            # Keep the in-memory copy in step with disk.
+            if nas_name in self.nas_configs:
+                self.nas_configs[nas_name]["device_id"] = device_id
+                self.nas_configs[nas_name]["otp_code"] = None
+
+            logger.info(f"Persisted refreshed device_id for '{nas_name}'")
+            return True
+        except (OSError, json.JSONDecodeError) as e:
+            logger.error(f"Failed to persist device_id for '{nas_name}': {e}")
+            return False
+
     def resolve_base_url(self, nas_name: str) -> Optional[str]:
         """Get the base_url for a NAS name, or None if not found."""
         cfg = self.nas_configs.get(nas_name)

--- a/src/config.py
+++ b/src/config.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import stat
+import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -566,7 +567,9 @@ class SynologyConfig:
             if entry is None:
                 logger.warning(f"Cannot persist device_id: NAS '{nas_name}' not in settings")
                 return False
-            if entry.get("device_id") == device_id:
+            token_changed = entry.get("device_id") != device_id
+            otp_present = "otp_code" in entry
+            if not token_changed and not otp_present:
                 return False  # unchanged, nothing to write
 
             entry["device_id"] = device_id
@@ -575,13 +578,19 @@ class SynologyConfig:
             # 2FA login and fail on a stale code.
             entry.pop("otp_code", None)
 
-            # Write via a 0600 temp file in the same directory, then rename, so
-            # the secrets never briefly exist world-readable and a crash
-            # mid-write cannot truncate the real file.
-            tmp = SETTINGS_FILE.with_suffix(".json.tmp")
-            tmp.write_text(json.dumps(data, indent=2) + "\n")
-            os.chmod(tmp, 0o600)
-            os.replace(tmp, SETTINGS_FILE)
+            # Write via a temp file in the same directory created with 0600
+            # from the start (mkstemp), then rename, so the secrets never
+            # briefly exist world-readable and a crash mid-write cannot
+            # truncate the real file.
+            fd, tmp_name = tempfile.mkstemp(
+                dir=SETTINGS_FILE.parent,
+                prefix=f".{SETTINGS_FILE.name}.",
+                suffix=".tmp",
+            )
+            with os.fdopen(fd, "w", encoding="utf-8") as tmp_file:
+                json.dump(data, tmp_file, indent=2)
+                tmp_file.write("\n")
+            os.replace(tmp_name, SETTINGS_FILE)
 
             # Keep the in-memory copy in step with disk.
             if nas_name in self.nas_configs:

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -339,11 +339,23 @@ class SynologyMCPServer:
         if nas_name is None:
             self.nas_name_map[base_url] = base_url
 
-        # Surface the DSM device token so users can copy it into settings.json
-        # (`device_id`) to skip OTP on future starts. Only present on the
-        # first-time OTP login.
+        # Persist the DSM device token rather than asking the user to copy it
+        # by hand. DSM may return a *refreshed* `did` on a login that already
+        # presented one, which retires the old value; keeping it only in
+        # memory means the token in settings.json is dead as soon as this
+        # process exits, and every later start falls back to "OTP required"
+        # (403). Only present when DSM issued one — i.e. the first-time OTP
+        # login (the steady-state `device_id` path doesn't echo it back).
         did = result["data"].get("did")
-        if did:
+        if did and nas_name:
+            if config.save_device_id(nas_name, did):
+                logger.info(f"{label}: stored refreshed device_id")
+        elif did:
+            # Legacy .env single-NAS mode has no settings.json entry to write
+            # into, so fall back to telling the user. Logged in full because
+            # (a) the value is destined for settings.json anyway and (b) it's
+            # useless without the password, so truncation provides no
+            # meaningful protection.
             logger.warning(
                 f"{label}: 2FA bootstrap - copy this device_id into "
                 f"settings.json to skip OTP on future starts: {did}"


### PR DESCRIPTION
### Problem

On a successful 2FA bootstrap DSM returns a `did` trusted-device token. Today it is only logged, with the user asked to paste it into `settings.json` by hand:

```
{label}: 2FA bootstrap — copy this device_id into settings.json to skip OTP on future starts: {did}
```

Two consequences:

1. For an MCP server, restarted every session, 2FA effectively works **once**. Every later start has no token and falls back to requiring an OTP, surfacing as a **403**.
2. Even a hand-copied token goes stale, because DSM can return a *refreshed* `did` on a later login that already presented one, retiring the previous value. Kept only in memory, that refreshed token dies with the process.

### Fix

Adds `SynologyConfig.save_device_id()`, called when a login yields a `did`. It rewrites only that NAS's `device_id` in `settings.json`, preserving everything else, and clears any spent one-shot `otp_code` alongside it — otherwise the next start looks like a first-time 2FA login and fails on a stale code.

The write goes to a `0600` temp file in the same directory followed by an atomic `os.replace`, so credentials are never briefly world-readable and a crash mid-write cannot truncate the real file. The in-memory config is updated to match.

The legacy `.env` single-NAS path has no `settings.json` entry to write into, so it keeps the existing "copy this by hand" warning.

### Note on #72

This introduces a **write** path to `settings.json`. #72 proposes enforcing Windows ACL policy on that file before load; the `0600`-then-rename here is POSIX-specific and would want the same treatment on Windows. Happy to align this with whatever #72 settles on, either in this PR or a follow-up.

### Testing

`pytest tests/` — 96 passed, 40 skipped, identical to `main` on the same machine. Verified end-to-end against DSM 7.4.1-90080: bootstrap with an OTP, then a restart with no OTP present, which previously returned 403 and now logs in from the persisted token.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically saves refreshed DSM trusted-device tokens for configured NAS devices.
  * Removes one-time login codes after successful token storage.
  * Preserves manual token-copy instructions for legacy single-NAS setups.

* **Bug Fixes**
  * Rejects invalid, unchanged, or unknown device entries without modifying settings.
  * Saves refreshed login information more reliably and securely.
  * Provides clearer handling when token storage fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->