### PR TITLE
fix: make verify_ssl a per-NAS setting and apply it to every client

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -9,6 +9,7 @@ import stat
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlsplit, urlunsplit
 
 from dotenv import load_dotenv
 
@@ -527,11 +528,47 @@ class SynologyConfig:
         available at those call sites. Falls back to the global setting for a
         base_url that matches no configured NAS (legacy .env single-NAS mode,
         or a session created by an explicit login tool call).
+
+        Both sides go through `_normalize_base_url` before matching: an
+        explicit login to `https://NAS.example` must still resolve the policy
+        of a NAS configured as `https://nas.example` — otherwise the global
+        fallback could silently *downgrade* verification for a NAS that asked
+        for it.
         """
+        target = self._normalize_base_url(base_url)
         for cfg in self.nas_configs.values():
-            if cfg.get("base_url") == base_url:
+            configured = cfg.get("base_url")
+            if configured and self._normalize_base_url(configured) == target:
                 return cfg.get("verify_ssl", self.verify_ssl)
         return self.verify_ssl
+
+    @staticmethod
+    def _normalize_base_url(url: str) -> str:
+        """Canonicalize a base URL for identity comparison.
+
+        URL identity is not string identity: scheme and hostname are
+        case-insensitive, an explicit default port (443/https, 80/http) is
+        equivalent to its omitted form, and a trailing slash on the path
+        carries no meaning here. The path itself is case-sensitive, so it is
+        preserved verbatim. Input without a parseable hostname is returned
+        as-is (minus trailing slash) and simply never matches a configured
+        URL, preserving the previous raw-equality behavior for it.
+        """
+        stripped = url.strip().rstrip("/")
+        parts = urlsplit(stripped)
+        if not parts.hostname:
+            return stripped
+        scheme = parts.scheme.lower()
+        try:
+            port = parts.port
+        except ValueError:
+            port = None
+        host = parts.hostname.lower()
+        if port is None or (scheme, port) in (("https", 443), ("http", 80)):
+            netloc = host
+        else:
+            netloc = f"{host}:{port}"
+        return urlunsplit((scheme, netloc, parts.path, "", ""))
 
     @staticmethod
     def get_config_dir() -> Path:

--- a/src/config.py
+++ b/src/config.py
@@ -153,6 +153,25 @@ class SynologyConfig:
             try:
                 data = json.loads(SETTINGS_FILE.read_text())
 
+                # Load server settings FIRST (they override env vars).
+                # The NAS loop below falls back to `self.verify_ssl` for any
+                # entry that does not set its own, so `server.verify_ssl` has
+                # to be applied before that loop runs. Parsed afterwards, the
+                # fallback silently used the environment value instead and a
+                # `server.verify_ssl` in settings.json never reached a NAS.
+                server_section = data.get("server", {})
+                if server_section:
+                    if "auto_login" in server_section:
+                        self.auto_login = server_section["auto_login"]
+                    if "verify_ssl" in server_section:
+                        self.verify_ssl = server_section["verify_ssl"]
+                    if "session_timeout" in server_section:
+                        self.default_session_timeout = server_section["session_timeout"]
+                    if "debug" in server_section:
+                        self.debug = server_section["debug"]
+                    if "log_level" in server_section:
+                        self.log_level = server_section["log_level"].upper()
+
                 # Load Synology NAS credentials
                 synology_section = data.get("synology", {})
 
@@ -199,11 +218,25 @@ class SynologyConfig:
                     scheme = "https" if port == 5001 else "http"
                     base_url = f"{scheme}://{host}:{port}"
 
+                    # Per-NAS override, falling back to the global server
+                    # setting applied above. A single global flag cannot serve
+                    # both a NAS with a real certificate (verification on) and
+                    # one addressed by IP with DSM's self-signed certificate
+                    # (verification off) once more than one NAS is configured.
+                    nas_verify_ssl = nas_info.get("verify_ssl", self.verify_ssl)
+                    if not isinstance(nas_verify_ssl, bool):
+                        logger.warning(
+                            f"Invalid 'verify_ssl' for NAS '{nas_name}' - expected "
+                            f"boolean, got {type(nas_verify_ssl)}; "
+                            f"falling back to {self.verify_ssl}"
+                        )
+                        nas_verify_ssl = self.verify_ssl
+
                     self.nas_configs[nas_name] = {
                         "base_url": base_url,
                         "username": username,
                         "password": password,
-                        "verify_ssl": self.verify_ssl,
+                        "verify_ssl": nas_verify_ssl,
                         "note": nas_info.get("note", ""),
                         "otp_code": otp_code,
                         "device_id": device_id,
@@ -218,20 +251,6 @@ class SynologyConfig:
                         "endpoint", "wss://api.xiaozhi.me/mcp/"
                     )
 
-                # Load server settings (override env vars if present)
-                server_section = data.get("server", {})
-                if server_section:
-                    if "auto_login" in server_section:
-                        self.auto_login = server_section["auto_login"]
-                    if "verify_ssl" in server_section:
-                        self.verify_ssl = server_section["verify_ssl"]
-                    if "session_timeout" in server_section:
-                        self.default_session_timeout = server_section["session_timeout"]
-                    if "debug" in server_section:
-                        self.debug = server_section["debug"]
-                    if "log_level" in server_section:
-                        self.log_level = server_section["log_level"].upper()
-
             except json.JSONDecodeError as e:
                 logger.error(f"Failed to parse {SETTINGS_FILE}: {e}")
             except OSError as e:
@@ -243,6 +262,19 @@ class SynologyConfig:
     # ------------------------------------------------------------------
     # Public helpers
     # ------------------------------------------------------------------
+
+    def verify_ssl_for(self, base_url: str) -> bool:
+        """Return the SSL verification policy for a NAS, by base URL.
+
+        Clients are created per base_url, which is the only NAS identity
+        available at those call sites. Falls back to the global setting for a
+        base_url that matches no configured NAS (legacy .env single-NAS mode,
+        or a session created by an explicit login tool call).
+        """
+        for cfg in self.nas_configs.values():
+            if cfg.get("base_url") == base_url:
+                return cfg.get("verify_ssl", self.verify_ssl)
+        return self.verify_ssl
 
     @staticmethod
     def get_config_dir() -> Path:

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -25,12 +25,25 @@ from health import SynologyHealth
 from nfs import SynologyNFS
 from usermanagement import SynologyUserManager
 
-# Suppress InsecureRequestWarning when verify_ssl is disabled (internal NAS devices)
-if not config.verify_ssl:
+# Suppress InsecureRequestWarning when verify_ssl is disabled (internal NAS devices).
+# urllib3's warning filter is process-global, so this has to consider any NAS that
+# turns verification off individually, not just the global setting.
+_unverified_nas = [
+    name
+    for name, cfg in config.nas_configs.items()
+    if not cfg.get("verify_ssl", config.verify_ssl)
+]
+if not config.verify_ssl or _unverified_nas:
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-    logger.warning(
-        "SSL verification is disabled. Set VERIFY_SSL=true if your NAS has a valid SSL certificate."
-    )
+    if not config.verify_ssl:
+        logger.warning(
+            "SSL verification is disabled. Set VERIFY_SSL=true if your NAS has a valid SSL certificate."
+        )
+    else:
+        logger.warning(
+            "SSL verification is disabled for: "
+            f"{', '.join(_unverified_nas)}. Certificate warnings are suppressed process-wide."
+        )
 
 
 class SynologyMCPServer:
@@ -92,7 +105,7 @@ class SynologyMCPServer:
             self.filestation_instances[base_url] = SynologyFileStation(
                 base_url,
                 session_id,
-                verify_ssl=config.verify_ssl,
+                verify_ssl=config.verify_ssl_for(base_url),
                 syno_token=self.syno_tokens.get(base_url),
             )
 
@@ -108,7 +121,7 @@ class SynologyMCPServer:
             self.downloadstation_instances[base_url] = SynologyDownloadStation(
                 base_url,
                 session_id,
-                verify_ssl=config.verify_ssl,
+                verify_ssl=config.verify_ssl_for(base_url),
                 syno_token=self.syno_tokens.get(base_url),
             )
 
@@ -124,7 +137,7 @@ class SynologyMCPServer:
             self.health_instances[base_url] = SynologyHealth(
                 base_url,
                 session_id,
-                verify_ssl=config.verify_ssl,
+                verify_ssl=config.verify_ssl_for(base_url),
                 syno_token=self.syno_tokens.get(base_url),
             )
 
@@ -140,7 +153,7 @@ class SynologyMCPServer:
             self.container_instances[base_url] = SynologyContainer(
                 base_url,
                 session_id,
-                verify_ssl=config.verify_ssl,
+                verify_ssl=config.verify_ssl_for(base_url),
                 syno_token=self.syno_tokens.get(base_url),
             )
 
@@ -156,7 +169,7 @@ class SynologyMCPServer:
             self.nfs_instances[base_url] = SynologyNFS(
                 base_url,
                 session_id,
-                verify_ssl=config.verify_ssl,
+                verify_ssl=config.verify_ssl_for(base_url),
                 syno_token=self.syno_tokens.get(base_url),
             )
 
@@ -172,7 +185,7 @@ class SynologyMCPServer:
             self.usermgr_instances[base_url] = SynologyUserManager(
                 base_url,
                 session_id,
-                verify_ssl=config.verify_ssl,
+                verify_ssl=config.verify_ssl_for(base_url),
                 syno_token=self.syno_tokens.get(base_url),
             )
 
@@ -205,7 +218,7 @@ class SynologyMCPServer:
 
                 if base_url not in self.auth_instances:
                     self.auth_instances[base_url] = SynologyAuth(
-                        base_url, verify_ssl=config.verify_ssl
+                        base_url, verify_ssl=config.verify_ssl_for(base_url)
                     )
 
                 auth = self.auth_instances[base_url]
@@ -491,7 +504,7 @@ class SynologyMCPServer:
 
         # Create or get auth instance
         if base_url not in self.auth_instances:
-            self.auth_instances[base_url] = SynologyAuth(base_url, verify_ssl=config.verify_ssl)
+            self.auth_instances[base_url] = SynologyAuth(base_url, verify_ssl=config.verify_ssl_for(base_url))
 
         auth = self.auth_instances[base_url]
         auth.on_relogin = self._resync_session_after_relogin

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -957,3 +957,104 @@ def test_config_str_representation():
 
                 assert "SynologyConfig" in cfg_str
                 assert "auto_login" in cfg_str
+
+
+class TestVerifySslFor:
+    """Per-NAS SSL policy resolution (verify_ssl_for), incl. URL normalization."""
+
+    @staticmethod
+    def _bare_config(nas_configs, global_verify):
+        """SynologyConfig without __init__ — verify_ssl_for needs no I/O."""
+        reload_config()
+        from config import SynologyConfig
+
+        cfg = SynologyConfig.__new__(SynologyConfig)
+        cfg.nas_configs = nas_configs
+        cfg.verify_ssl = global_verify
+        return cfg
+
+    def test_exact_match_returns_per_nas_policy(self):
+        cfg = self._bare_config(
+            {"nas1": {"base_url": "https://192.168.1.100:5001", "verify_ssl": True}},
+            global_verify=False,
+        )
+        assert cfg.verify_ssl_for("https://192.168.1.100:5001") is True
+
+    def test_hostname_case_does_not_downgrade_verification(self):
+        """A case-variant explicit-login URL must keep the NAS's own policy.
+
+        Regression test: raw string equality fell back to the global policy,
+        so global=False + per-NAS=True silently disabled verification for a
+        NAS that asked for it.
+        """
+        cfg = self._bare_config(
+            {"nas1": {"base_url": "https://MyNAS.example:5001", "verify_ssl": True}},
+            global_verify=False,
+        )
+        assert cfg.verify_ssl_for("https://mynas.example:5001") is True
+
+    def test_scheme_case_and_trailing_slash_match(self):
+        cfg = self._bare_config(
+            {"nas1": {"base_url": "http://nas.example:5000", "verify_ssl": True}},
+            global_verify=False,
+        )
+        assert cfg.verify_ssl_for("HTTP://nas.example:5000/") is True
+
+    def test_default_port_matches_omitted_form(self):
+        cfg = self._bare_config(
+            {"nas1": {"base_url": "https://nas.example:443", "verify_ssl": True}},
+            global_verify=False,
+        )
+        assert cfg.verify_ssl_for("https://nas.example") is True
+
+    def test_unknown_url_falls_back_to_global(self):
+        cfg = self._bare_config(
+            {"nas1": {"base_url": "https://nas.example:5001", "verify_ssl": True}},
+            global_verify=False,
+        )
+        assert cfg.verify_ssl_for("https://other.example:5001") is False
+
+    def test_nas_without_own_policy_uses_global(self):
+        cfg = self._bare_config(
+            {"nas1": {"base_url": "https://nas.example:5001"}},
+            global_verify=True,
+        )
+        assert cfg.verify_ssl_for("https://nas.example:5001") is True
+
+    def test_per_nas_policy_end_to_end_via_settings(self, tmp_path):
+        """settings.json per-NAS verify_ssl flows through to verify_ssl_for."""
+        secrets_data = {
+            "synology": {
+                "ip-nas": {
+                    "host": "192.168.1.8",
+                    "port": 5000,
+                    "username": "a",
+                    "password": "b",
+                    "verify_ssl": False,
+                },
+                "cert-nas": {
+                    "host": "nas.example",
+                    "port": 5001,
+                    "username": "c",
+                    "password": "d",
+                    "verify_ssl": True,
+                },
+            },
+            "server": {"verify_ssl": True},
+        }
+        secrets_file = tmp_path / "settings.json"
+        secrets_file.write_text(json.dumps(secrets_data))
+        os.chmod(str(secrets_file), 0o600)  # config refuses insecure-perm files
+
+        reload_config()
+
+        with clear_env():
+            with patch("config.SETTINGS_FILE", secrets_file):
+                from config import SynologyConfig
+
+                cfg = SynologyConfig()
+
+                # server.verify_ssl applied before the NAS loop (PR #78 fix)
+                assert cfg.verify_ssl is True
+                assert cfg.verify_ssl_for("http://192.168.1.8:5000") is False
+                assert cfg.verify_ssl_for("https://NAS.example:5001") is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1039,6 +1039,16 @@ class TestVerifySslFor:
                     "password": "d",
                     "verify_ssl": True,
                 },
+                # No verify_ssl of its own: must inherit the server value,
+                # which only happens if server settings load before the NAS
+                # loop. Under the old ordering this NAS got the env default
+                # (False) even with server.verify_ssl: true.
+                "plain-nas": {
+                    "host": "192.168.1.9",
+                    "port": 5000,
+                    "username": "e",
+                    "password": "f",
+                },
             },
             "server": {"verify_ssl": True},
         }
@@ -1058,3 +1068,7 @@ class TestVerifySslFor:
                 assert cfg.verify_ssl is True
                 assert cfg.verify_ssl_for("http://192.168.1.8:5000") is False
                 assert cfg.verify_ssl_for("https://NAS.example:5001") is True
+                # Ordering path: NAS without its own key inherits the server
+                # value, not the env default (False)
+                assert cfg.nas_configs["plain-nas"]["verify_ssl"] is True
+                assert cfg.verify_ssl_for("http://192.168.1.9:5000") is True


### PR DESCRIPTION
Follow-up to #76, which was narrowed to the `url` key alone after review. This is the `verify_ssl` half, done properly. Independent of #76 — they touch different lines and can merge in either order.

### Why per-NAS

One global flag cannot serve a multi-NAS setup. A NAS published with a real certificate wants verification on; a second addressed by IP with DSM's self-signed certificate wants it off. Today the two cannot coexist.

### Three defects, fixed together

Any one of these alone leaves the setting half-applied, which is worse than not having it.

**1. Ordering — `server.verify_ssl` never reached a NAS.** The NAS loop runs before the `server` section is parsed, so a NAS falls back to `self.verify_ssl` while that still holds the environment value. This is pre-existing on `main`: setting `server.verify_ssl: true` in `settings.json` today has no effect on any NAS client. Server settings are now parsed first.

**2. Propagation — 8 construction sites, not 1.** Clients are built with the global value at the six service getters (`_get_filestation`, `_get_downloadstation`, `_get_health`, `_get_container`, `_get_nfs`, `_get_usermgr`) *and* at both `SynologyAuth` sites — auto-login and the re-auth path at what was line 505. A per-NAS value reaching only the login path lets a NAS verify at login and then skip verification on every subsequent API call, or silently disable verification for a NAS configured `verify_ssl: true`. All 8 now resolve by `base_url`.

**3. Warning suppression was keyed off the global flag.** `urllib3`'s filter is process-global. With the global on and one NAS opting out, every request from that NAS would emit `InsecureRequestWarning`. It now triggers on any NAS that turns verification off and names them in the log line, so the gap stays visible rather than being blanket-suppressed.

### Shape

Resolution lives on the config object:

```python
config.verify_ssl_for(base_url)  # falls back to the global for an unknown base_url
```

`base_url` is the only NAS identity available at the client construction sites, so that is what it keys on. Unknown URLs (legacy `.env` single-NAS mode, or a session from an explicit login tool call) fall back to the global setting.

As asked in #76 — happy to move this to a lookup performed by the server instead of a helper on `SynologyConfig` if you prefer that split. It is a small change and I would rather match your preference than leave it as I guessed.

### Compatibility

Backwards compatible. `verify_ssl` stays optional per NAS and the global remains the fallback. Non-boolean values are rejected with a warning and fall back to the global, matching the existing entry validation. Behaviour is unchanged for anyone not setting a per-NAS value — except that `server.verify_ssl` now actually applies, which is the point of fix 1.

### Testing

`pytest tests/` — 96 passed, 40 skipped, identical to `main` on the same machine.

Functionally verified with a three-NAS config (global `true`, one entry `false`, one deliberately malformed):

```
Invalid 'verify_ssl' for NAS 'bogusval' - expected boolean, got <class 'str'>; falling back to True
global verify_ssl: True
  proxied   verify_ssl=True   via verify_ssl_for()=True
  byip      verify_ssl=False  via verify_ssl_for()=False
  bogusval  verify_ssl=True   via verify_ssl_for()=True
unknown base_url falls back to: True
```

`proxied` resolving to `True` is fix 1 — on `main` it takes the environment value (`False`) despite `server.verify_ssl: true` being set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring SSL verification independently for each NAS.
  * NAS-specific SSL settings now override the global server setting when configured.
  * SSL policies are matched consistently across equivalent NAS URLs.
  * SSL warnings identify affected NAS configurations when applicable.

* **Bug Fixes**
  * Authentication and cached services now consistently apply the correct SSL verification policy for each NAS.
  * Global SSL settings are used reliably when no NAS-specific setting is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->