### PR TITLE
feat(config): enforce Windows ACL policy on settings.json before loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,12 +589,16 @@ The docker-compose.yml automatically mounts your `~/.config/synology-mcp` direct
     ```powershell
     # The server loads settings from here (matches src/config.py SETTINGS_FILE):
     $f = "$env:USERPROFILE\.config\synology-mcp\settings.json"
-    # Remove inheritance and strip all existing ACEs, then grant the
-    # current user and Administrators full control (no other principals).
+    # /inheritance:r removes inherited ACEs but leaves explicit ones in place,
+    # and /grant:r only replaces the explicit ACE for the named principal — so
+    # revoke every existing explicit grant first, then grant the current user
+    # and Administrators full control (no other principals).
     icacls $f /inheritance:r
+    icacls $f /remove:g "Everyone" "BUILTIN\Users" "Authenticated Users"
     icacls $f /grant:r "${env:USERNAME}:(F)"
     icacls $f /grant:r "Administrators:(F)"
     ```
+    If the file is brand new, the `/remove:g` step is a harmless no-op.
   - Verify: `icacls "$env:USERPROFILE\.config\synology-mcp\settings.json"` — only your user and `Administrators` should appear.
 
 **SSL Certificate Verification (VERIFY_SSL):**

--- a/README.md
+++ b/README.md
@@ -587,30 +587,39 @@ The docker-compose.yml automatically mounts your `~/.config/synology-mcp` direct
   - Lock down the file from an elevated PowerShell prompt (uses the same path the server loads):
 
     ```powershell
-    # The server loads settings from here (matches src/config.py SETTINGS_FILE):
-    $f = "$env:USERPROFILE\.config\synology-mcp\settings.json"
-    # Reset inheritance, revoke every existing grant, then grant only the
-    # current user and Administrators full control.
+    # Resolve the path the SAME way the server does: $XDG_CONFIG_HOME if set,
+    # otherwise %USERPROFILE%\.config. This honors the override documented above.
+    $cfg = if ($env:XDG_CONFIG_HOME) { $env:XDG_CONFIG_HOME } else { "$env:USERPROFILE\.config" }
+    $f = "$cfg\synology-mcp\settings.json"
+
+    # The server's ACL audit requires: owner == current user, no NULL DACL, and
+    # no allow-ACE outside {current user, SYSTEM, Administrators}. The steps
+    # below enforce all three.
     #
-    # Use the *<SID> form for built-in principals: account names like
-    # "Administrators" are localized on non-English Windows (e.g. German
-    # "Administratoren"), which breaks the recipe. S-1-5-32-544 is the
-    # locale-independent SID for BUILTIN\Administrators.
+    # Use the *<SID> form for every built-in principal: account names like
+    # "Administrators" / "Everyone" / "Users" are localized on non-English
+    # Windows (e.g. German "Administratoren") and won't resolve. The
+    # locale-independent SIDs:
+    #   *S-1-1-0            Everyone
+    #   *S-1-5-11           Authenticated Users
+    #   *S-1-5-32-545       BUILTIN\Users
+    #   *S-1-5-32-544       BUILTIN\Administrators
     #
-    # /inheritance:r removes inherited ACEs but leaves explicit ones, and
-    # /grant:r only replaces the named principal's grant, so first audit
-    # the current ACL and revoke any explicit grant that is NOT your user
-    # or Administrators. The common foreign principals are revoked below;
-    # if `icacls $f` shows any other trustee, remove it too before granting.
+    # 1. Ensure the file is owned by the current user (the audit rejects any
+    #    other owner). /setowner requires elevation.
+    icacls $f /setowner "${env:USERNAME}"
+    # 2. Drop inherited ACEs, then revoke the common foreign grants. /grant:r
+    #    only replaces the named principal, so revoke first.
     icacls $f /inheritance:r
-    icacls $f /remove:g "Everyone" "BUILTIN\Users" "Authenticated Users"
+    icacls $f /remove:g "*S-1-1-0" "*S-1-5-11" "*S-1-5-32-545"
     # Re-run `icacls $f` here; if any principal other than your user or
     # Administrators still appears, run: icacls $f /remove:g "<that principal>"
+    # 3. Grant the current user and Administrators full control.
     icacls $f /grant:r "${env:USERNAME}:(F)"
     icacls $f /grant:r "*S-1-5-32-544:(F)"   # BUILTIN\Administrators (locale-independent)
     ```
     If the file is brand new, the `/remove:g` step is a harmless no-op.
-  - Verify: `icacls "$env:USERPROFILE\.config\synology-mcp\settings.json"` — only your user and `Administrators` (or `*S-1-5-32-544`) should appear.
+  - Verify: `icacls "$f"` — only your user and `*S-1-5-32-544` (Administrators) should appear.
 
 **SSL Certificate Verification (VERIFY_SSL):**
 - Default is `false` to support self-signed certificates on internal NAS devices

--- a/README.md
+++ b/README.md
@@ -579,6 +579,22 @@ The docker-compose.yml automatically mounts your `~/.config/synology-mcp` direct
 
 ### ⚠️ Security Recommendations
 
+**settings.json File Permissions:**
+- **Linux/macOS (POSIX):** `chmod 600 ~/.config/synology-mcp/settings.json` is required. The server refuses to load the file if it is group- or world-readable/writable, or owned by another user.
+- **Windows:** Access control is enforced via NTFS ACLs, not POSIX mode bits. The server checks the file's owner SID against the current user's SID and refuses to load if they differ.
+  - Requires the optional [`pywin32`](https://pypi.org/project/pywin32/) package: `pip install pywin32`. Without it the ACL check is skipped with a warning and the file loads unverified.
+  - Expected ACL shape: only the current user should have access. Remove any grants to `BUILTIN\Users`, `Everyone`, or other principals.
+  - Lock down the file from an Administrator PowerShell prompt (replace `<YourUser>`):
+
+    ```powershell
+    # Remove inheritance and strip all existing ACEs, then grant the
+    # current user full control and Administrators full control.
+    icacls "$env:APPDATA\synology-mcp\settings.json" /inheritance:r
+    icacls "$env:APPDATA\synology-mcp\settings.json" /grant:r "${env:USERNAME}:(F)"
+    icacls "$env:APPDATA\synology-mcp\settings.json" /grant:r "Administrators:(F)"
+    ```
+  - Verify: `icacls "$env:APPDATA\synology-mcp\settings.json"` — only your user and `Administrators` should appear.
+
 **SSL Certificate Verification (VERIFY_SSL):**
 - Default is `false` to support self-signed certificates on internal NAS devices
 - **If your NAS has a valid SSL certificate (e.g., from Let's Encrypt or a corporate CA), set `VERIFY_SSL=true`**

--- a/README.md
+++ b/README.md
@@ -581,19 +581,21 @@ The docker-compose.yml automatically mounts your `~/.config/synology-mcp` direct
 
 **settings.json File Permissions:**
 - **Linux/macOS (POSIX):** `chmod 600 ~/.config/synology-mcp/settings.json` is required. The server refuses to load the file if it is group- or world-readable/writable, or owned by another user.
-- **Windows:** Access control is enforced via NTFS ACLs, not POSIX mode bits. The server checks the file's owner SID against the current user's SID and refuses to load if they differ.
-  - Requires the optional [`pywin32`](https://pypi.org/project/pywin32/) package: `pip install pywin32`. Without it the ACL check is skipped with a warning and the file loads unverified.
-  - Expected ACL shape: only the current user should have access. Remove any grants to `BUILTIN\Users`, `Everyone`, or other principals.
-  - Lock down the file from an Administrator PowerShell prompt (replace `<YourUser>`):
+- **Windows:** Access control is enforced via NTFS ACLs, not POSIX mode bits. The server audits the file's security descriptor and refuses to load unless **all three** hold: (1) the owner SID matches the current user; (2) the DACL is present (a NULL DACL — "everyone full access" — is rejected); (3) no allow-ACE grants access to a principal outside the allowlist: the current user, `NT AUTHORITY\SYSTEM`, and `BUILTIN\Administrators`. Any inherited `Everyone` / `BUILTIN\Users` / `Authenticated Users` grant fails the check.
+  - Requires the optional [`pywin32`](https://pypi.org/project/pywin32/) package: `pip install pywin32`. **If pywin32 is not installed, the server fails closed and refuses to load `settings.json`.** Operators who accept the risk of an unverified file can opt back in by setting `SYNOLOGY_MCP_ALLOW_UNVERIFIED_WINDOWS_ACL=true`.
+  - The server resolves the file via `XDG_CONFIG_HOME` (default `Path.home() / ".config"`), so on Windows it lives at `%USERPROFILE%\.config\synology-mcp\settings.json` unless `XDG_CONFIG_HOME` is set.
+  - Lock down the file from an elevated PowerShell prompt (uses the same path the server loads):
 
     ```powershell
+    # The server loads settings from here (matches src/config.py SETTINGS_FILE):
+    $f = "$env:USERPROFILE\.config\synology-mcp\settings.json"
     # Remove inheritance and strip all existing ACEs, then grant the
-    # current user full control and Administrators full control.
-    icacls "$env:APPDATA\synology-mcp\settings.json" /inheritance:r
-    icacls "$env:APPDATA\synology-mcp\settings.json" /grant:r "${env:USERNAME}:(F)"
-    icacls "$env:APPDATA\synology-mcp\settings.json" /grant:r "Administrators:(F)"
+    # current user and Administrators full control (no other principals).
+    icacls $f /inheritance:r
+    icacls $f /grant:r "${env:USERNAME}:(F)"
+    icacls $f /grant:r "Administrators:(F)"
     ```
-  - Verify: `icacls "$env:APPDATA\synology-mcp\settings.json"` — only your user and `Administrators` should appear.
+  - Verify: `icacls "$env:USERPROFILE\.config\synology-mcp\settings.json"` — only your user and `Administrators` should appear.
 
 **SSL Certificate Verification (VERIFY_SSL):**
 - Default is `false` to support self-signed certificates on internal NAS devices

--- a/README.md
+++ b/README.md
@@ -589,17 +589,28 @@ The docker-compose.yml automatically mounts your `~/.config/synology-mcp` direct
     ```powershell
     # The server loads settings from here (matches src/config.py SETTINGS_FILE):
     $f = "$env:USERPROFILE\.config\synology-mcp\settings.json"
-    # /inheritance:r removes inherited ACEs but leaves explicit ones in place,
-    # and /grant:r only replaces the explicit ACE for the named principal — so
-    # revoke every existing explicit grant first, then grant the current user
-    # and Administrators full control (no other principals).
+    # Reset inheritance, revoke every existing grant, then grant only the
+    # current user and Administrators full control.
+    #
+    # Use the *<SID> form for built-in principals: account names like
+    # "Administrators" are localized on non-English Windows (e.g. German
+    # "Administratoren"), which breaks the recipe. S-1-5-32-544 is the
+    # locale-independent SID for BUILTIN\Administrators.
+    #
+    # /inheritance:r removes inherited ACEs but leaves explicit ones, and
+    # /grant:r only replaces the named principal's grant, so first audit
+    # the current ACL and revoke any explicit grant that is NOT your user
+    # or Administrators. The common foreign principals are revoked below;
+    # if `icacls $f` shows any other trustee, remove it too before granting.
     icacls $f /inheritance:r
     icacls $f /remove:g "Everyone" "BUILTIN\Users" "Authenticated Users"
+    # Re-run `icacls $f` here; if any principal other than your user or
+    # Administrators still appears, run: icacls $f /remove:g "<that principal>"
     icacls $f /grant:r "${env:USERNAME}:(F)"
-    icacls $f /grant:r "Administrators:(F)"
+    icacls $f /grant:r "*S-1-5-32-544:(F)"   # BUILTIN\Administrators (locale-independent)
     ```
     If the file is brand new, the `/remove:g` step is a harmless no-op.
-  - Verify: `icacls "$env:USERPROFILE\.config\synology-mcp\settings.json"` — only your user and `Administrators` should appear.
+  - Verify: `icacls "$env:USERPROFILE\.config\synology-mcp\settings.json"` — only your user and `Administrators` (or `*S-1-5-32-544`) should appear.
 
 **SSL Certificate Verification (VERIFY_SSL):**
 - Default is `false` to support self-signed certificates on internal NAS devices

--- a/src/config.py
+++ b/src/config.py
@@ -115,9 +115,9 @@ class SynologyConfig:
         Prints warning if permissions are too open.
 
         POSIX: checks file ownership and group/other permission bits.
-        Windows: uses pywin32 (win32security) to verify the file owner SID
-        matches the current user. Falls back to a warning if pywin32 is not
-        installed.
+        Windows: full ACL audit via pywin32 (owner SID match + DACL allowlist).
+        Fails closed if pywin32 is missing; opt back in with
+        ``SYNOLOGY_MCP_ALLOW_UNVERIFIED_WINDOWS_ACL=true``.
         Other platforms without os.getuid(): skipped with a warning, returns
         True (unverified).
         """
@@ -156,25 +156,44 @@ class SynologyConfig:
     def _check_windows_file_permissions(self, path: Path) -> bool:
         """Check Windows ACL for settings.json.
 
-        Uses pywin32 (win32security) to verify the file owner SID matches the
-        current user. This is a simplified check — a full DACL audit is not
-        performed. The expected ACL grants access to the current user only.
+        Enforces the policy from issue #72: the file must grant access only to
+        the current user (plus a small system allowlist). Concretely:
 
-        pywin32 is an optional dependency. Without it the check is skipped with
-        a warning and the file is treated as acceptable (returns True).
+        1. The owner SID must match the current user.
+        2. The DACL must be present (a NULL DACL means "everyone full access"
+           and is rejected).
+        3. No allow-ACE may grant access to a principal outside the allowlist:
+           the current user, ``NT AUTHORITY\\SYSTEM``, and
+           ``BUILTIN\\Administrators``. Inherited ``Everyone`` /
+           ``BUILTIN\\Users`` / ``Authenticated Users`` grants fail the check.
+
+        pywin32 is an **optional** dependency. If it is not installed the check
+        **fails closed** (returns ``False``) so credentials are never loaded
+        unverified. Operators who accept the risk can opt back in to the old
+        unverified-load behaviour by setting
+        ``SYNOLOGY_MCP_ALLOW_UNVERIFIED_WINDOWS_ACL=true``.
         """
         try:
-            import win32file  # noqa: F401 - ensure win32file is available
+            import ntsecuritycon
+            import win32api
             import win32security
+        except ImportError:
+            return self._windows_acl_unavailable(path)
 
-            sd = win32security.GetFileSecurity(
-                str(path), win32security.OWNER_SECURITY_INFORMATION
+        try:
+            # OWNER + DACL: we need both to enforce the policy. OWNER alone is
+            # not enough — a file owned by the current user can still inherit
+            # an Everyone/BUILTIN\Users allow-ACE from its parent folder.
+            info = (
+                win32security.OWNER_SECURITY_INFORMATION
+                | win32security.DACL_SECURITY_INFORMATION
             )
+            sd = win32security.GetFileSecurity(str(path), info)
             owner_sid = sd.GetSecurityDescriptorOwner()
 
-            # Get the current user's SID
+            # Current user SID via the process token.
             token = win32security.OpenProcessToken(
-                win32security.GetCurrentProcess(),
+                win32api.GetCurrentProcess(),
                 win32security.TOKEN_QUERY,
             )
             token_info = win32security.GetTokenInformation(token, win32security.TokenUser)
@@ -187,21 +206,94 @@ class SynologyConfig:
                 )
                 return False
 
+            # Build the allowlist of trusted trustee SIDs. We compare SIDs as
+            # strings (sid.__str__) for stability against pywin32's PySID
+            # object identity quirks.
+            allowed_sid_strs = {str(current_sid)}
+            for well_known in ("SYSTEM", "Administrators"):
+                try:
+                    sid, _, _ = win32security.LookupAccountName(
+                        None,  # local machine
+                        well_known if well_known != "Administrators" else "BUILTIN\\Administrators",
+                    )
+                    allowed_sid_strs.add(str(sid))
+                except Exception:
+                    # Best-effort: if we can't resolve a well-known SID, skip it
+                    # rather than widening the check incorrectly.
+                    pass
+
+            dacl = sd.GetSecurityDescriptorDacl()
+            if dacl is None:
+                # NULL DACL: no access control — anyone can read/write. Reject.
+                logger.warning(
+                    f"{path} has a NULL DACL (no access control). "
+                    "Refusing to load. Restrict the file to your user; see README."
+                )
+                return False
+
+            for ace in dacl:
+                # Only allow-ACEs (ACCESS_ALLOWED_ACE_TYPE) widen access;
+                # deny-ACEs only narrow it, so leave them through.
+                try:
+                    ace_type = ace[0][1]
+                except Exception:
+                    ace_type = None
+                if ace_type != ntsecuritycon.ACCESS_ALLOWED_ACE_TYPE:
+                    continue
+
+                try:
+                    trustee_sid = ace[2]
+                    trustee_sid_str = str(trustee_sid)
+                except Exception as e:
+                    logger.warning(
+                        f"{path} has an ACE whose trustee could not be read ({e}); "
+                        "failing closed."
+                    )
+                    return False
+
+                if trustee_sid_str not in allowed_sid_strs:
+                    logger.warning(
+                        f"{path} DACL grants access to a principal outside the "
+                        f"allowlist (SID={trustee_sid_str}). "
+                        "Restrict the file to your user; see README."
+                    )
+                    return False
+
             logger.info(
-                f"Windows ACL check passed for {path} (owner SID verified as current user)"
+                f"Windows ACL check passed for {path} "
+                "(owner verified, no foreign allow-ACE in DACL)"
             )
             return True
 
-        except ImportError:
-            logger.warning(
-                f"pywin32 not installed. Windows ACL check for {path} SKIPPED — "
-                "file permissions were NOT verified. "
-                "Install pywin32 to enable Windows ACL enforcement."
-            )
-            return True
         except Exception as e:
             logger.warning(f"Windows ACL check failed for {path}: {e}")
             return False
+
+    @staticmethod
+    def _windows_acl_unavailable(path: Path) -> bool:
+        """Handle pywin32 being unavailable on Windows.
+
+        Default is fail-closed: refuse to load credentials we can't verify.
+        Operators who accept the risk of an unverified settings.json can set
+        ``SYNOLOGY_MCP_ALLOW_UNVERIFIED_WINDOWS_ACL=true`` to restore the old
+        load-anyway behaviour.
+        """
+        allow_unverified = os.getenv(
+            "SYNOLOGY_MCP_ALLOW_UNVERIFIED_WINDOWS_ACL", "false"
+        ).lower() == "true"
+        if allow_unverified:
+            logger.warning(
+                f"pywin32 not installed. Windows ACL check for {path} SKIPPED "
+                "(SYNOLOGY_MCP_ALLOW_UNVERIFIED_WINDOWS_ACL=true). "
+                "File permissions were NOT verified — install pywin32 to enable enforcement."
+            )
+            return True
+        logger.error(
+            f"pywin32 not installed; cannot verify Windows ACL for {path}. "
+            "Refusing to load credentials. Either install pywin32 or set "
+            "SYNOLOGY_MCP_ALLOW_UNVERIFIED_WINDOWS_ACL=true to accept the risk."
+        )
+        return False
 
     def _load_settings(self):
         """Load all settings from XDG config directory (~/.config/synology-mcp/settings.json)."""

--- a/src/config.py
+++ b/src/config.py
@@ -248,12 +248,18 @@ class SynologyConfig:
             # types, audit the trustee. For ANYTHING ELSE (callback, dynamic,
             # or future types), fail closed — we can't prove they don't widen.
             allow_type = ntsecuritycon.ACCESS_ALLOWED_ACE_TYPE
+            # Fallback values per WinNT.h / MS-DTYP §2.4.4.1:
+            #   ACCESS_ALLOWED_OBJECT_ACE_TYPE = 5, ACCESS_DENIED_OBJECT_ACE_TYPE = 6,
+            #   ACCESS_DENIED_ACE_TYPE = 1, SYSTEM_AUDIT_ACE_TYPE = 2,
+            #   SYSTEM_ALARM_ACE_TYPE = 3.
+            # getattr() reads the real ntsecuritycon first; the literal is only
+            # a defensive default if an attribute is missing.
             allow_object_type = getattr(
-                ntsecuritycon, "ACCESS_ALLOWED_OBJECT_ACE_TYPE", 6
+                ntsecuritycon, "ACCESS_ALLOWED_OBJECT_ACE_TYPE", 5
             )
             deny_type = getattr(ntsecuritycon, "ACCESS_DENIED_ACE_TYPE", 1)
             deny_object_type = getattr(
-                ntsecuritycon, "ACCESS_DENIED_OBJECT_ACE_TYPE", 7
+                ntsecuritycon, "ACCESS_DENIED_OBJECT_ACE_TYPE", 6
             )
             # Types that provably don't widen access: deny types (narrow) and
             # SACL audit types (no access effect). Everything else must be

--- a/src/config.py
+++ b/src/config.py
@@ -192,12 +192,13 @@ class SynologyConfig:
             owner_sid = sd.GetSecurityDescriptorOwner()
 
             # Current user SID via the process token.
+            # GetTokenInformation(TokenUser) returns a (sid, attributes) tuple.
             token = win32security.OpenProcessToken(
                 win32api.GetCurrentProcess(),
                 win32security.TOKEN_QUERY,
             )
-            token_info = win32security.GetTokenInformation(token, win32security.TokenUser)
-            current_sid = token_info["UserSid"]
+            token_user = win32security.GetTokenInformation(token, win32security.TokenUser)
+            current_sid = token_user[0]
 
             if current_sid != owner_sid:
                 logger.warning(
@@ -231,17 +232,26 @@ class SynologyConfig:
                 )
                 return False
 
-            for ace in dacl:
-                # Only allow-ACEs (ACCESS_ALLOWED_ACE_TYPE) widen access;
-                # deny-ACEs only narrow it, so leave them through.
+            # PyACL: enumerate via GetAceCount()/GetAce(i) — it is NOT directly
+            # iterable on real Windows (pywin32 returns a PyACL object).
+            ace_count = dacl.GetAceCount()
+            for i in range(ace_count):
+                ace = dacl.GetAce(i)
+                # ACE tuple shape: ((ace_type, ace_flags), mask, (sid,)).
+                # ace_type is ace[0][0] — ace[0][1] is the *flags* (e.g.
+                # INHERITED_ACE), which would misclassify an inherited
+                # allow-ACE as a deny and let it through. Only allow-ACEs
+                # (ACCESS_ALLOWED_ACE_TYPE) widen access; deny-ACEs only
+                # narrow it, so leave them through.
                 try:
-                    ace_type = ace[0][1]
+                    ace_type = ace[0][0]
                 except Exception:
                     ace_type = None
                 if ace_type != ntsecuritycon.ACCESS_ALLOWED_ACE_TYPE:
                     continue
 
                 try:
+                    # Trustee SID is ace[2] (a PySID tuple on real Windows).
                     trustee_sid = ace[2]
                     trustee_sid_str = str(trustee_sid)
                 except Exception as e:

--- a/src/config.py
+++ b/src/config.py
@@ -114,19 +114,16 @@ class SynologyConfig:
         Returns True if permissions are safe, False otherwise.
         Prints warning if permissions are too open.
 
-        POSIX only. On Windows os.getuid() does not exist and st_mode carries
-        no meaningful group/other bits, so this check raised AttributeError and
-        took the whole settings load down with it.
-
-        On Windows the check is SKIPPED and this returns True so the settings
-        file still loads. Be clear about what that means: True here means
-        "not checked", not "verified safe". Windows access control lives in
-        ACLs, which this function cannot read. The alternative -- returning
-        False -- would make secrets.json unusable on Windows entirely, which is
-        a worse outcome than an unverified file, but it does mean a
-        world-readable secrets.json will load without complaint. The warning
-        below is deliberately not debug-level so the gap is visible in logs.
+        POSIX: checks file ownership and group/other permission bits.
+        Windows: uses pywin32 (win32security) to verify the file owner SID
+        matches the current user. Falls back to a warning if pywin32 is not
+        installed.
+        Other platforms without os.getuid(): skipped with a warning, returns
+        True (unverified).
         """
+        if os.name == "nt":
+            return self._check_windows_file_permissions(path)
+
         if not hasattr(os, "getuid"):
             logger.warning(
                 f"Permission check for {path} SKIPPED: this platform has no POSIX "
@@ -135,6 +132,7 @@ class SynologyConfig:
             )
             return True
 
+        # POSIX fallback (original logic)
         try:
             file_stat = path.stat()
             mode = file_stat.st_mode
@@ -153,6 +151,56 @@ class SynologyConfig:
             return True
         except OSError as e:
             logger.warning(f"Could not check permissions for {path}: {e}")
+            return False
+
+    def _check_windows_file_permissions(self, path: Path) -> bool:
+        """Check Windows ACL for settings.json.
+
+        Uses pywin32 (win32security) to verify the file owner SID matches the
+        current user. This is a simplified check — a full DACL audit is not
+        performed. The expected ACL grants access to the current user only.
+
+        pywin32 is an optional dependency. Without it the check is skipped with
+        a warning and the file is treated as acceptable (returns True).
+        """
+        try:
+            import win32file  # noqa: F401 - ensure win32file is available
+            import win32security
+
+            sd = win32security.GetFileSecurity(
+                str(path), win32security.OWNER_SECURITY_INFORMATION
+            )
+            owner_sid = sd.GetSecurityDescriptorOwner()
+
+            # Get the current user's SID
+            token = win32security.OpenProcessToken(
+                win32security.GetCurrentProcess(),
+                win32security.TOKEN_QUERY,
+            )
+            token_info = win32security.GetTokenInformation(token, win32security.TokenUser)
+            current_sid = token_info["UserSid"]
+
+            if current_sid != owner_sid:
+                logger.warning(
+                    f"{path} owner SID does not match current user. "
+                    "Expected ACL to restrict access to the current user only."
+                )
+                return False
+
+            logger.info(
+                f"Windows ACL check passed for {path} (owner SID verified as current user)"
+            )
+            return True
+
+        except ImportError:
+            logger.warning(
+                f"pywin32 not installed. Windows ACL check for {path} SKIPPED — "
+                "file permissions were NOT verified. "
+                "Install pywin32 to enable Windows ACL enforcement."
+            )
+            return True
+        except Exception as e:
+            logger.warning(f"Windows ACL check failed for {path}: {e}")
             return False
 
     def _load_settings(self):

--- a/src/config.py
+++ b/src/config.py
@@ -234,25 +234,38 @@ class SynologyConfig:
 
             # PyACL: enumerate via GetAceCount()/GetAce(i) — it is NOT directly
             # iterable on real Windows (pywin32 returns a PyACL object).
+            allow_type = ntsecuritycon.ACCESS_ALLOWED_ACE_TYPE
+            allow_object_type = getattr(
+                ntsecuritycon, "ACCESS_ALLOWED_OBJECT_ACE_TYPE", 6
+            )
+            # ACE tuple shapes returned by pywin32's PyACL.GetAce(i):
+            #   conventional: ((ace_type, ace_flags), mask, sid)
+            #   object:       ((ace_type, ace_flags), mask, object_type,
+            #                  inherited_object_type, sid)
+            # Conventional trustee SID is ace[2]; object ACE trustee is ace[-1].
             ace_count = dacl.GetAceCount()
             for i in range(ace_count):
                 ace = dacl.GetAce(i)
-                # ACE tuple shape: ((ace_type, ace_flags), mask, (sid,)).
                 # ace_type is ace[0][0] — ace[0][1] is the *flags* (e.g.
                 # INHERITED_ACE), which would misclassify an inherited
-                # allow-ACE as a deny and let it through. Only allow-ACEs
-                # (ACCESS_ALLOWED_ACE_TYPE) widen access; deny-ACEs only
-                # narrow it, so leave them through.
+                # allow-ACE as a deny and let it through.
                 try:
                     ace_type = ace[0][0]
                 except Exception:
                     ace_type = None
-                if ace_type != ntsecuritycon.ACCESS_ALLOWED_ACE_TYPE:
+
+                # Only ALLOW-type ACEs widen access. DENY-type ACEs (and any
+                # allow-type we don't recognise) only narrow or preserve it.
+                # ACCESS_ALLOWED_ACE_TYPE (0) and ACCESS_ALLOWED_OBJECT_ACE_TYPE
+                # (6) are the two allow types; both must be audited.
+                is_allow = ace_type in (allow_type, allow_object_type)
+                if not is_allow:
                     continue
 
                 try:
-                    # Trustee SID is ace[2] (a PySID tuple on real Windows).
-                    trustee_sid = ace[2]
+                    # Object ACEs carry extra fields before the SID; ace[-1]
+                    # is the trustee for both shapes.
+                    trustee_sid = ace[2] if ace_type == allow_type else ace[-1]
                     trustee_sid_str = str(trustee_sid)
                 except Exception as e:
                     logger.warning(
@@ -264,7 +277,7 @@ class SynologyConfig:
                 if trustee_sid_str not in allowed_sid_strs:
                     logger.warning(
                         f"{path} DACL grants access to a principal outside the "
-                        f"allowlist (SID={trustee_sid_str}). "
+                        f"allowlist (SID={trustee_sid_str}, ace_type={ace_type}). "
                         "Restrict the file to your user; see README."
                     )
                     return False

--- a/src/config.py
+++ b/src/config.py
@@ -234,10 +234,37 @@ class SynologyConfig:
 
             # PyACL: enumerate via GetAceCount()/GetAce(i) — it is NOT directly
             # iterable on real Windows (pywin32 returns a PyACL object).
+            #
+            # ACE type semantics (Win32):
+            #   0 ACCESS_ALLOWED_ACE_TYPE              — widens (grant)
+            #   1 ACCESS_DENIED_ACE_TYPE               — narrows (deny)
+            #   6 ACCESS_ALLOWED_OBJECT_ACE_TYPE       — widens (object grant)
+            #   7 ACCESS_DENIED_OBJECT_ACE_TYPE        — narrows (object deny)
+            #   9 ACCESS_ALLOWED_CALLBACK_ACE_TYPE     — widens (conditional)
+            #  11 ACCESS_ALLOWED_CALLBACK_OBJECT_ACE_TYPE — widens (conditional obj)
+            #   2/3 SYSTEM_AUDIT / SYSTEM_ALARM         — audit, not access
+            #
+            # Strategy: explicitly enumerate the DENY and audit types we know
+            # are safe to skip (they don't widen access). For the known ALLOW
+            # types, audit the trustee. For ANYTHING ELSE (callback, dynamic,
+            # or future types), fail closed — we can't prove they don't widen.
             allow_type = ntsecuritycon.ACCESS_ALLOWED_ACE_TYPE
             allow_object_type = getattr(
                 ntsecuritycon, "ACCESS_ALLOWED_OBJECT_ACE_TYPE", 6
             )
+            deny_type = getattr(ntsecuritycon, "ACCESS_DENIED_ACE_TYPE", 1)
+            deny_object_type = getattr(
+                ntsecuritycon, "ACCESS_DENIED_OBJECT_ACE_TYPE", 7
+            )
+            # Types that provably don't widen access: deny types (narrow) and
+            # SACL audit types (no access effect). Everything else must be
+            # audited or rejected.
+            safe_to_skip = {
+                deny_type,
+                deny_object_type,
+                getattr(ntsecuritycon, "SYSTEM_AUDIT_ACE_TYPE", 2),
+                getattr(ntsecuritycon, "SYSTEM_ALARM_ACE_TYPE", 3),
+            }
             # ACE tuple shapes returned by pywin32's PyACL.GetAce(i):
             #   conventional: ((ace_type, ace_flags), mask, sid)
             #   object:       ((ace_type, ace_flags), mask, object_type,
@@ -254,18 +281,29 @@ class SynologyConfig:
                 except Exception:
                     ace_type = None
 
-                # Only ALLOW-type ACEs widen access. DENY-type ACEs (and any
-                # allow-type we don't recognise) only narrow or preserve it.
-                # ACCESS_ALLOWED_ACE_TYPE (0) and ACCESS_ALLOWED_OBJECT_ACE_TYPE
-                # (6) are the two allow types; both must be audited.
-                is_allow = ace_type in (allow_type, allow_object_type)
-                if not is_allow:
+                # Known-safe non-widening types (deny / audit) narrow or have
+                # no access effect — skip them.
+                if ace_type in safe_to_skip:
                     continue
 
+                # Known allow types — audit the trustee against the allowlist.
+                if ace_type == allow_type:
+                    trustee_index = 2
+                elif ace_type == allow_object_type:
+                    trustee_index = -1
+                else:
+                    # Unrecognised type (callback, conditional, dynamic, or a
+                    # future type). We can't prove it doesn't widen access, so
+                    # fail closed rather than risk a silent bypass.
+                    logger.warning(
+                        f"{path} DACL contains an ACE of unrecognised type "
+                        f"({ace_type}); failing closed. "
+                        "Restrict the file to your user; see README."
+                    )
+                    return False
+
                 try:
-                    # Object ACEs carry extra fields before the SID; ace[-1]
-                    # is the trustee for both shapes.
-                    trustee_sid = ace[2] if ace_type == allow_type else ace[-1]
+                    trustee_sid = ace[trustee_index]
                     trustee_sid_str = str(trustee_sid)
                 except Exception as e:
                     logger.warning(

--- a/src/config.py
+++ b/src/config.py
@@ -210,18 +210,17 @@ class SynologyConfig:
             # Build the allowlist of trusted trustee SIDs. We compare SIDs as
             # strings (sid.__str__) for stability against pywin32's PySID
             # object identity quirks.
-            allowed_sid_strs = {str(current_sid)}
-            for well_known in ("SYSTEM", "Administrators"):
-                try:
-                    sid, _, _ = win32security.LookupAccountName(
-                        None,  # local machine
-                        well_known if well_known != "Administrators" else "BUILTIN\\Administrators",
-                    )
-                    allowed_sid_strs.add(str(sid))
-                except Exception:
-                    # Best-effort: if we can't resolve a well-known SID, skip it
-                    # rather than widening the check incorrectly.
-                    pass
+            #
+            # Use well-known SID *literals* rather than LookupAccountName:
+            # account names are localized on non-English Windows (e.g. German
+            # "Administratoren"), so LookupAccountName("Administrators") can
+            # fail and drop S-1-5-32-544 from the allowlist — rejecting a
+            # normal secured DACL. The SID strings are locale-independent.
+            allowed_sid_strs = {
+                str(current_sid),
+                "S-1-5-18",       # NT AUTHORITY\SYSTEM
+                "S-1-5-32-544",   # BUILTIN\Administrators
+            }
 
             dacl = sd.GetSecurityDescriptorDacl()
             if dacl is None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -334,14 +334,21 @@ class TestWindowsAclFallback:
     def _ace(trustee_sid_str, ace_type=0, ace_flags=0):
         """Build a fake ACE tuple matching pywin32's real shape.
 
-        Real pywin32 ACE: ((ace_type, ace_flags), mask, trustee_sid).
-        ace_type 0 = ACCESS_ALLOWED_ACE_TYPE, 1 = ACCESS_DENIED_ACE_TYPE.
+        Real pywin32 ACE shapes returned by PyACL.GetAce(i):
+          conventional: ((ace_type, ace_flags), mask, sid)
+          object:       ((ace_type, ace_flags), mask, object_type,
+                         inherited_object_type, sid)
+        ace_type 0 = ACCESS_ALLOWED_ACE_TYPE, 1 = ACCESS_DENIED_ACE_TYPE,
+        6 = ACCESS_ALLOWED_OBJECT_ACE_TYPE, 7 = ACCESS_DENIED_OBJECT_ACE_TYPE.
         ace_flags includes INHERITED_ACE (0x10) for ACEs inherited from a
         parent folder — the case Codex flagged as misclassified by the old
         ace[0][1] read.
         """
         header = (ace_type, ace_flags)
         mask = 0x1F01FF  # full control placeholder
+        if ace_type in (6, 7):
+            # Object ACE: ((type, flags), mask, obj_type, inh_obj_type, sid)
+            return (header, mask, None, None, trustee_sid_str)
         return (header, mask, trustee_sid_str)
 
     def _build_fakes(self, *, owner_sid, dacl_aces=None, dacl_is_null=False):
@@ -412,6 +419,7 @@ class TestWindowsAclFallback:
 
         fake_ntsecuritycon = types.ModuleType("ntsecuritycon")
         fake_ntsecuritycon.ACCESS_ALLOWED_ACE_TYPE = 0
+        fake_ntsecuritycon.ACCESS_ALLOWED_OBJECT_ACE_TYPE = 6
 
         return {
             "win32security": fake_win32security,
@@ -643,6 +651,65 @@ class TestWindowsAclFallback:
                 self._ace(self.CURRENT_SID),
                 # 1 = ACCESS_DENIED_ACE_TYPE — narrowing, should be ignored.
                 self._ace(self.EVERYONE_SID, ace_type=1),
+            ],
+        )
+
+        config_mod = self._load_fresh_config()
+        cfg = config_mod.SynologyConfig.__new__(config_mod.SynologyConfig)
+
+        with patch.dict(sys.modules, fakes):
+            with caplog.at_level(logging.INFO, logger="synology-mcp"):
+                result = cfg._check_windows_file_permissions(secrets_file)
+
+        assert result is True
+
+    def test_foreign_object_allow_ace_returns_false(self, tmp_path, caplog):
+        """An ACCESS_ALLOWED_OBJECT_ACE_TYPE for Everyone must fail the check.
+
+        Object ACEs carry the trustee SID at ace[-1] (not ace[2]). The audit
+        must treat type 6 as an allow ACE and read the trustee from the right
+        index, otherwise a foreign object-allow grant is silently skipped.
+        """
+        import logging
+        import sys
+
+        secrets_file = tmp_path / "settings.json"
+        secrets_file.write_text("{}")
+
+        fakes = self._build_fakes(
+            owner_sid=self.CURRENT_SID,
+            dacl_aces=[
+                self._ace(self.CURRENT_SID),
+                # 6 = ACCESS_ALLOWED_OBJECT_ACE_TYPE — widening, foreign trustee.
+                self._ace(self.EVERYONE_SID, ace_type=6),
+            ],
+        )
+
+        config_mod = self._load_fresh_config()
+        cfg = config_mod.SynologyConfig.__new__(config_mod.SynologyConfig)
+
+        with patch.dict(sys.modules, fakes):
+            with caplog.at_level(logging.WARNING, logger="synology-mcp"):
+                result = cfg._check_windows_file_permissions(secrets_file)
+
+        assert result is False
+        assert any(
+            "outside the allowlist" in rec.message.lower() for rec in caplog.records
+        )
+
+    def test_allowlisted_object_ace_passes(self, tmp_path, caplog):
+        """An object-allow ACE for an allowlisted principal passes."""
+        import logging
+        import sys
+
+        secrets_file = tmp_path / "settings.json"
+        secrets_file.write_text("{}")
+
+        fakes = self._build_fakes(
+            owner_sid=self.CURRENT_SID,
+            dacl_aces=[
+                self._ace(self.CURRENT_SID),
+                self._ace(self.ADMINS_SID, ace_type=6),
             ],
         )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -306,6 +306,212 @@ class TestFilePermissions:
                 assert any("permission" in rec.message.lower() for rec in caplog.records)
 
 
+class TestWindowsAclFallback:
+    """Test Windows ACL check fallback when pywin32 is unavailable.
+
+    pywin32 is Windows-only and not installed in CI/dev on macOS/Linux, so we
+    drive _check_windows_file_permissions() in isolation. Each test injects a
+    fake ``win32security`` / ``win32file`` module (or none) into sys.modules so
+    the method's optional-dependency import either succeeds with a stub or
+    raises ImportError, exercising both branches.
+    """
+
+    def _load_fresh_config(self):
+        """Import a fresh SynologyConfig class (avoids module-level caching)."""
+        reload_config()
+        import config as config_mod
+
+        return config_mod
+
+    def test_fallback_returns_true_without_pywin32(self, tmp_path, caplog):
+        """Without pywin32 the check is skipped and returns True (unverified)."""
+        import logging
+        import sys
+
+        secrets_file = tmp_path / "settings.json"
+        secrets_file.write_text("{}")
+
+        # Ensure no pywin32 modules are importable
+        removed = {}
+        for mod_name in ("win32security", "win32file"):
+            if mod_name in sys.modules:
+                removed[mod_name] = sys.modules.pop(mod_name)
+
+        config_mod = self._load_fresh_config()
+        cfg = config_mod.SynologyConfig.__new__(config_mod.SynologyConfig)
+
+        try:
+            with caplog.at_level(logging.WARNING, logger="synology-mcp"):
+                result = cfg._check_windows_file_permissions(secrets_file)
+
+            assert result is True
+            assert any(
+                "pywin32 not installed" in rec.message.lower()
+                or "pywin32" in rec.message.lower()
+                for rec in caplog.records
+            )
+        finally:
+            sys.modules.update(removed)
+
+    def test_owner_match_returns_true(self, tmp_path, caplog):
+        """When owner SID equals current user SID, the check passes."""
+        import logging
+        import sys
+        import types
+
+        secrets_file = tmp_path / "settings.json"
+        secrets_file.write_text("{}")
+
+        same_sid = "S-1-5-21-currentuser"
+
+        # Build a fake win32security module with the constants/callables the
+        # method uses. Constants can be arbitrary ints; only equality matters.
+        fake_win32security = types.ModuleType("win32security")
+        fake_win32security.OWNER_SECURITY_INFORMATION = 1
+        fake_win32security.TOKEN_QUERY = 8
+        fake_win32security.TokenUser = 1
+
+        def _get_file_security(_path, _info):
+            sd = types.SimpleNamespace(GetSecurityDescriptorOwner=lambda: same_sid)
+            return sd
+
+        def _get_current_process():
+            return "fake-process-handle"
+
+        def _open_process_token(_proc, _access):
+            return "fake-token-handle"
+
+        def _get_token_information(_token, _class):
+            return {"UserSid": same_sid}
+
+        fake_win32security.GetFileSecurity = _get_file_security
+        fake_win32security.GetCurrentProcess = _get_current_process
+        fake_win32security.OpenProcessToken = _open_process_token
+        fake_win32security.GetTokenInformation = _get_token_information
+
+        fake_win32file = types.ModuleType("win32file")
+
+        config_mod = self._load_fresh_config()
+        cfg = config_mod.SynologyConfig.__new__(config_mod.SynologyConfig)
+
+        with patch.dict(
+            sys.modules,
+            {"win32security": fake_win32security, "win32file": fake_win32file},
+        ):
+            with caplog.at_level(logging.INFO, logger="synology-mcp"):
+                result = cfg._check_windows_file_permissions(secrets_file)
+
+        assert result is True
+        assert any(
+            "windows acl check passed" in rec.message.lower() for rec in caplog.records
+        )
+
+    def test_owner_mismatch_returns_false(self, tmp_path, caplog):
+        """When owner SID differs from current user SID, the check fails."""
+        import logging
+        import sys
+        import types
+
+        secrets_file = tmp_path / "settings.json"
+        secrets_file.write_text("{}")
+
+        owner_sid = "S-1-5-21-someone-else"
+        current_sid = "S-1-5-21-currentuser"
+
+        fake_win32security = types.ModuleType("win32security")
+        fake_win32security.OWNER_SECURITY_INFORMATION = 1
+        fake_win32security.TOKEN_QUERY = 8
+        fake_win32security.TokenUser = 1
+
+        def _get_file_security(_path, _info):
+            sd = types.SimpleNamespace(GetSecurityDescriptorOwner=lambda: owner_sid)
+            return sd
+
+        fake_win32security.GetFileSecurity = _get_file_security
+        fake_win32security.GetCurrentProcess = lambda: "proc"
+        fake_win32security.OpenProcessToken = lambda _p, _a: "token"
+        fake_win32security.GetTokenInformation = lambda _t, _c: {"UserSid": current_sid}
+
+        fake_win32file = types.ModuleType("win32file")
+
+        config_mod = self._load_fresh_config()
+        cfg = config_mod.SynologyConfig.__new__(config_mod.SynologyConfig)
+
+        with patch.dict(
+            sys.modules,
+            {"win32security": fake_win32security, "win32file": fake_win32file},
+        ):
+            with caplog.at_level(logging.WARNING, logger="synology-mcp"):
+                result = cfg._check_windows_file_permissions(secrets_file)
+
+        assert result is False
+        assert any(
+            "owner sid does not match" in rec.message.lower() for rec in caplog.records
+        )
+
+    def test_win32_runtime_failure_returns_false(self, tmp_path, caplog):
+        """A runtime error from win32security fails the check (fail-closed)."""
+        import logging
+        import sys
+        import types
+
+        secrets_file = tmp_path / "settings.json"
+        secrets_file.write_text("{}")
+
+        fake_win32security = types.ModuleType("win32security")
+        fake_win32security.OWNER_SECURITY_INFORMATION = 1
+        fake_win32security.TOKEN_QUERY = 8
+        fake_win32security.TokenUser = 1
+
+        def _boom(*_args, **_kwargs):
+            raise OSError("denied")
+
+        fake_win32security.GetFileSecurity = _boom
+        fake_win32security.GetCurrentProcess = _boom
+        fake_win32security.OpenProcessToken = _boom
+        fake_win32security.GetTokenInformation = _boom
+
+        fake_win32file = types.ModuleType("win32file")
+
+        config_mod = self._load_fresh_config()
+        cfg = config_mod.SynologyConfig.__new__(config_mod.SynologyConfig)
+
+        with patch.dict(
+            sys.modules,
+            {"win32security": fake_win32security, "win32file": fake_win32file},
+        ):
+            with caplog.at_level(logging.WARNING, logger="synology-mcp"):
+                result = cfg._check_windows_file_permissions(secrets_file)
+
+        assert result is False
+        assert any(
+            "windows acl check failed" in rec.message.lower() for rec in caplog.records
+        )
+
+    def test_dispatch_on_nt_calls_windows_check(self, tmp_path):
+        """_check_file_permissions routes to the Windows check when os.name == 'nt'."""
+        import sys
+
+        secrets_file = tmp_path / "settings.json"
+        secrets_file.write_text("{}")
+
+        config_mod = self._load_fresh_config()
+        cfg = config_mod.SynologyConfig.__new__(config_mod.SynologyConfig)
+
+        called = {"count": 0}
+
+        def _stub(_path):
+            called["count"] += 1
+            return True
+
+        with patch.object(config_mod.os, "name", "nt"):
+            with patch.object(cfg, "_check_windows_file_permissions", _stub):
+                result = cfg._check_file_permissions(secrets_file)
+
+        assert result is True
+        assert called["count"] == 1
+
+
 def test_config_str_representation():
     """Test string representation of config."""
     reload_config()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -338,15 +338,16 @@ class TestWindowsAclFallback:
           conventional: ((ace_type, ace_flags), mask, sid)
           object:       ((ace_type, ace_flags), mask, object_type,
                          inherited_object_type, sid)
-        ace_type 0 = ACCESS_ALLOWED_ACE_TYPE, 1 = ACCESS_DENIED_ACE_TYPE,
-        6 = ACCESS_ALLOWED_OBJECT_ACE_TYPE, 7 = ACCESS_DENIED_OBJECT_ACE_TYPE.
+        Per WinNT.h:
+          0 = ACCESS_ALLOWED_ACE_TYPE, 1 = ACCESS_DENIED_ACE_TYPE,
+          5 = ACCESS_ALLOWED_OBJECT_ACE_TYPE, 6 = ACCESS_DENIED_OBJECT_ACE_TYPE.
         ace_flags includes INHERITED_ACE (0x10) for ACEs inherited from a
         parent folder — the case Codex flagged as misclassified by the old
         ace[0][1] read.
         """
         header = (ace_type, ace_flags)
         mask = 0x1F01FF  # full control placeholder
-        if ace_type in (6, 7):
+        if ace_type in (5, 6):
             # Object ACE: ((type, flags), mask, obj_type, inh_obj_type, sid)
             return (header, mask, None, None, trustee_sid_str)
         return (header, mask, trustee_sid_str)
@@ -419,7 +420,8 @@ class TestWindowsAclFallback:
 
         fake_ntsecuritycon = types.ModuleType("ntsecuritycon")
         fake_ntsecuritycon.ACCESS_ALLOWED_ACE_TYPE = 0
-        fake_ntsecuritycon.ACCESS_ALLOWED_OBJECT_ACE_TYPE = 6
+        # Real WinNT.h value is 5 (ACCESS_ALLOWED_OBJECT_ACE_TYPE).
+        fake_ntsecuritycon.ACCESS_ALLOWED_OBJECT_ACE_TYPE = 5
 
         return {
             "win32security": fake_win32security,
@@ -667,8 +669,9 @@ class TestWindowsAclFallback:
         """An ACCESS_ALLOWED_OBJECT_ACE_TYPE for Everyone must fail the check.
 
         Object ACEs carry the trustee SID at ace[-1] (not ace[2]). The audit
-        must treat type 6 as an allow ACE and read the trustee from the right
-        index, otherwise a foreign object-allow grant is silently skipped.
+        must treat type 5 (ACCESS_ALLOWED_OBJECT_ACE_TYPE per WinNT.h) as an
+        allow ACE and read the trustee from the right index, otherwise a
+        foreign object-allow grant is silently skipped.
         """
         import logging
         import sys
@@ -680,8 +683,8 @@ class TestWindowsAclFallback:
             owner_sid=self.CURRENT_SID,
             dacl_aces=[
                 self._ace(self.CURRENT_SID),
-                # 6 = ACCESS_ALLOWED_OBJECT_ACE_TYPE — widening, foreign trustee.
-                self._ace(self.EVERYONE_SID, ace_type=6),
+                # 5 = ACCESS_ALLOWED_OBJECT_ACE_TYPE — widening, foreign trustee.
+                self._ace(self.EVERYONE_SID, ace_type=5),
             ],
         )
 
@@ -709,7 +712,7 @@ class TestWindowsAclFallback:
             owner_sid=self.CURRENT_SID,
             dacl_aces=[
                 self._ace(self.CURRENT_SID),
-                self._ace(self.ADMINS_SID, ace_type=6),
+                self._ace(self.ADMINS_SID, ace_type=5),
             ],
         )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -331,22 +331,43 @@ class TestWindowsAclFallback:
         return config_mod
 
     @staticmethod
-    def _ace(trustee_sid_str, ace_type=0):
-        """Build a fake ACE tuple matching the (header, mask, trustee) layout."""
-        # ace[0][1] is the ACE type (0 = ACCESS_ALLOWED_ACE_TYPE)
-        header = (0, ace_type, 0)
+    def _ace(trustee_sid_str, ace_type=0, ace_flags=0):
+        """Build a fake ACE tuple matching pywin32's real shape.
+
+        Real pywin32 ACE: ((ace_type, ace_flags), mask, trustee_sid).
+        ace_type 0 = ACCESS_ALLOWED_ACE_TYPE, 1 = ACCESS_DENIED_ACE_TYPE.
+        ace_flags includes INHERITED_ACE (0x10) for ACEs inherited from a
+        parent folder — the case Codex flagged as misclassified by the old
+        ace[0][1] read.
+        """
+        header = (ace_type, ace_flags)
         mask = 0x1F01FF  # full control placeholder
         return (header, mask, trustee_sid_str)
 
     def _build_fakes(self, *, owner_sid, dacl_aces=None, dacl_is_null=False):
         """Build fake win32security/win32api/ntsecuritycon modules.
 
-        ``dacl_aces`` is a list of ACE tuples; ``dacl_is_null`` simulates a
-        NULL DACL (GetSecurityDescriptorDacl returns None).
+        The fakes mirror pywin32's real API shape so the tests exercise the
+        same code paths that run on Windows:
+
+        - GetTokenInformation(TokenUser) returns a (sid, attributes) tuple.
+        - GetSecurityDescriptorDacl() returns a PyACL-like object exposing
+          GetAceCount() and GetAce(i) (NOT direct iteration).
+        - ACE tuples are ((ace_type, ace_flags), mask, trustee_sid).
         """
         import types
 
-        same_sid = owner_sid
+        class _FakeAcl:
+            """Minimal PyACL stand-in: GetAceCount + GetAce(i)."""
+
+            def __init__(self, aces):
+                self._aces = list(aces or [])
+
+            def GetAceCount(self):
+                return len(self._aces)
+
+            def GetAce(self, i):
+                return self._aces[i]
 
         fake_win32security = types.ModuleType("win32security")
         fake_win32security.OWNER_SECURITY_INFORMATION = 1
@@ -361,7 +382,7 @@ class TestWindowsAclFallback:
             def _dacl():
                 if dacl_is_null:
                     return None
-                return list(dacl_aces or [])
+                return _FakeAcl(dacl_aces or [])
 
             return types.SimpleNamespace(
                 GetSecurityDescriptorOwner=_owner,
@@ -370,7 +391,11 @@ class TestWindowsAclFallback:
 
         fake_win32security.GetFileSecurity = _get_file_security
         fake_win32security.OpenProcessToken = lambda _p, _a: "token"
-        fake_win32security.GetTokenInformation = lambda _t, _c: {"UserSid": self.CURRENT_SID}
+        # Real pywin32: GetTokenInformation(TokenUser) -> (sid, attributes).
+        fake_win32security.GetTokenInformation = lambda _t, _c: (
+            self.CURRENT_SID,
+            0,
+        )
 
         def _lookup(_sys, name):
             # Map well-known names back to their SIDs.
@@ -552,6 +577,43 @@ class TestWindowsAclFallback:
             dacl_aces=[
                 self._ace(self.CURRENT_SID),
                 self._ace(self.EVERYONE_SID),
+            ],
+        )
+
+        config_mod = self._load_fresh_config()
+        cfg = config_mod.SynologyConfig.__new__(config_mod.SynologyConfig)
+
+        with patch.dict(sys.modules, fakes):
+            with caplog.at_level(logging.WARNING, logger="synology-mcp"):
+                result = cfg._check_windows_file_permissions(secrets_file)
+
+        assert result is False
+        assert any(
+            "outside the allowlist" in rec.message.lower() for rec in caplog.records
+        )
+
+    def test_inherited_foreign_allow_ace_returns_false(self, tmp_path, caplog):
+        """An INHERITED allow-ACE for Everyone must still fail the check.
+
+        Regression guard: the old code read ace[0][1] (flags) instead of
+        ace[0][0] (type), so an inherited allow-ACE (type=0, flags=0x10
+        INHERITED_ACE) was misclassified as "not allowed" and skipped —
+        letting an inherited Everyone grant through. This test fails under
+        that bug and passes with the correct ace[0][0] read.
+        """
+        import logging
+        import sys
+
+        secrets_file = tmp_path / "settings.json"
+        secrets_file.write_text("{}")
+
+        fakes = self._build_fakes(
+            owner_sid=self.CURRENT_SID,
+            dacl_aces=[
+                self._ace(self.CURRENT_SID),
+                # type=0 (ALLOWED), flags=0x10 (INHERITED_ACE) → real shape of
+                # an ACE inherited from a parent folder granting Everyone read.
+                self._ace(self.EVERYONE_SID, ace_type=0, ace_flags=0x10),
             ],
         )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -722,6 +722,41 @@ class TestWindowsAclFallback:
 
         assert result is True
 
+    def test_unrecognised_ace_type_fails_closed(self, tmp_path, caplog):
+        """An ACE of unrecognised type fails closed (no silent bypass).
+
+        Covers callback/conditional/dynamic ACE types (9, 11, …) that could
+        widen access but whose shape we don't model. Rather than skip them
+        and risk a foreign grant slipping through, the check rejects the
+        file. Also covers a totally unknown type (e.g. 99).
+        """
+        import logging
+        import sys
+
+        secrets_file = tmp_path / "settings.json"
+        secrets_file.write_text("{}")
+
+        for unknown_type in (9, 11, 99):
+            fakes = self._build_fakes(
+                owner_sid=self.CURRENT_SID,
+                dacl_aces=[
+                    self._ace(self.CURRENT_SID),
+                    self._ace(self.EVERYONE_SID, ace_type=unknown_type),
+                ],
+            )
+
+            config_mod = self._load_fresh_config()
+            cfg = config_mod.SynologyConfig.__new__(config_mod.SynologyConfig)
+
+            with patch.dict(sys.modules, fakes):
+                with caplog.at_level(logging.WARNING, logger="synology-mcp"):
+                    result = cfg._check_windows_file_permissions(secrets_file)
+
+            assert result is False, f"type {unknown_type} should fail closed"
+            assert any(
+                "unrecognised" in rec.message.lower() for rec in caplog.records
+            )
+
     def test_win32_runtime_failure_returns_false(self, tmp_path, caplog):
         """A runtime error from win32security fails the check (fail-closed)."""
         import logging

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -307,14 +307,21 @@ class TestFilePermissions:
 
 
 class TestWindowsAclFallback:
-    """Test Windows ACL check fallback when pywin32 is unavailable.
+    """Test Windows ACL enforcement.
 
     pywin32 is Windows-only and not installed in CI/dev on macOS/Linux, so we
-    drive _check_windows_file_permissions() in isolation. Each test injects a
-    fake ``win32security`` / ``win32file`` module (or none) into sys.modules so
-    the method's optional-dependency import either succeeds with a stub or
-    raises ImportError, exercising both branches.
+    drive _check_windows_file_permissions() in isolation. Each test injects
+    fake ``win32security`` / ``win32api`` / ``ntsecuritycon`` modules (or none)
+    into sys.modules via patch.dict so the method's optional-dependency import
+    either succeeds with a stub or raises ImportError, exercising both
+    branches. Setting a sys.modules entry to ``None`` makes the import raise
+    ModuleNotFoundError, which we use for the missing-pywin32 tests.
     """
+
+    CURRENT_SID = "S-1-5-21-currentuser"
+    SYSTEM_SID = "S-1-5-18"
+    ADMINS_SID = "S-1-5-32-544"
+    EVERYONE_SID = "S-1-1-0"
 
     def _load_fresh_config(self):
         """Import a fresh SynologyConfig class (avoids module-level caching)."""
@@ -323,81 +330,153 @@ class TestWindowsAclFallback:
 
         return config_mod
 
-    def test_fallback_returns_true_without_pywin32(self, tmp_path, caplog):
-        """Without pywin32 the check is skipped and returns True (unverified)."""
-        import logging
-        import sys
+    @staticmethod
+    def _ace(trustee_sid_str, ace_type=0):
+        """Build a fake ACE tuple matching the (header, mask, trustee) layout."""
+        # ace[0][1] is the ACE type (0 = ACCESS_ALLOWED_ACE_TYPE)
+        header = (0, ace_type, 0)
+        mask = 0x1F01FF  # full control placeholder
+        return (header, mask, trustee_sid_str)
 
-        secrets_file = tmp_path / "settings.json"
-        secrets_file.write_text("{}")
+    def _build_fakes(self, *, owner_sid, dacl_aces=None, dacl_is_null=False):
+        """Build fake win32security/win32api/ntsecuritycon modules.
 
-        # Ensure no pywin32 modules are importable
-        removed = {}
-        for mod_name in ("win32security", "win32file"):
-            if mod_name in sys.modules:
-                removed[mod_name] = sys.modules.pop(mod_name)
-
-        config_mod = self._load_fresh_config()
-        cfg = config_mod.SynologyConfig.__new__(config_mod.SynologyConfig)
-
-        try:
-            with caplog.at_level(logging.WARNING, logger="synology-mcp"):
-                result = cfg._check_windows_file_permissions(secrets_file)
-
-            assert result is True
-            assert any(
-                "pywin32 not installed" in rec.message.lower()
-                or "pywin32" in rec.message.lower()
-                for rec in caplog.records
-            )
-        finally:
-            sys.modules.update(removed)
-
-    def test_owner_match_returns_true(self, tmp_path, caplog):
-        """When owner SID equals current user SID, the check passes."""
-        import logging
-        import sys
+        ``dacl_aces`` is a list of ACE tuples; ``dacl_is_null`` simulates a
+        NULL DACL (GetSecurityDescriptorDacl returns None).
+        """
         import types
 
-        secrets_file = tmp_path / "settings.json"
-        secrets_file.write_text("{}")
+        same_sid = owner_sid
 
-        same_sid = "S-1-5-21-currentuser"
-
-        # Build a fake win32security module with the constants/callables the
-        # method uses. Constants can be arbitrary ints; only equality matters.
         fake_win32security = types.ModuleType("win32security")
         fake_win32security.OWNER_SECURITY_INFORMATION = 1
+        fake_win32security.DACL_SECURITY_INFORMATION = 4
         fake_win32security.TOKEN_QUERY = 8
         fake_win32security.TokenUser = 1
 
         def _get_file_security(_path, _info):
-            sd = types.SimpleNamespace(GetSecurityDescriptorOwner=lambda: same_sid)
-            return sd
+            def _owner():
+                return owner_sid
 
-        def _get_current_process():
-            return "fake-process-handle"
+            def _dacl():
+                if dacl_is_null:
+                    return None
+                return list(dacl_aces or [])
 
-        def _open_process_token(_proc, _access):
-            return "fake-token-handle"
-
-        def _get_token_information(_token, _class):
-            return {"UserSid": same_sid}
+            return types.SimpleNamespace(
+                GetSecurityDescriptorOwner=_owner,
+                GetSecurityDescriptorDacl=_dacl,
+            )
 
         fake_win32security.GetFileSecurity = _get_file_security
-        fake_win32security.GetCurrentProcess = _get_current_process
-        fake_win32security.OpenProcessToken = _open_process_token
-        fake_win32security.GetTokenInformation = _get_token_information
+        fake_win32security.OpenProcessToken = lambda _p, _a: "token"
+        fake_win32security.GetTokenInformation = lambda _t, _c: {"UserSid": self.CURRENT_SID}
 
-        fake_win32file = types.ModuleType("win32file")
+        def _lookup(_sys, name):
+            # Map well-known names back to their SIDs.
+            mapping = {
+                "SYSTEM": self.SYSTEM_SID,
+                "BUILTIN\\Administrators": self.ADMINS_SID,
+            }
+            return (mapping.get(name, "S-1-0-0"), None, None)
+
+        fake_win32security.LookupAccountName = _lookup
+
+        fake_win32api = types.ModuleType("win32api")
+        fake_win32api.GetCurrentProcess = lambda: "proc"
+
+        fake_ntsecuritycon = types.ModuleType("ntsecuritycon")
+        fake_ntsecuritycon.ACCESS_ALLOWED_ACE_TYPE = 0
+
+        return {
+            "win32security": fake_win32security,
+            "win32api": fake_win32api,
+            "ntsecuritycon": fake_ntsecuritycon,
+        }
+
+    def test_missing_pywin32_fails_closed_by_default(self, tmp_path, caplog):
+        """Without pywin32, the check fails closed (returns False)."""
+        import logging
+        import sys
+
+        secrets_file = tmp_path / "settings.json"
+        secrets_file.write_text("{}")
+
+        # Setting sys.modules entries to None forces ImportError on import.
+        blocked = {
+            "win32security": None,
+            "win32api": None,
+            "ntsecuritycon": None,
+            "win32file": None,
+        }
 
         config_mod = self._load_fresh_config()
         cfg = config_mod.SynologyConfig.__new__(config_mod.SynologyConfig)
 
-        with patch.dict(
-            sys.modules,
-            {"win32security": fake_win32security, "win32file": fake_win32file},
-        ):
+        with patch.dict(sys.modules, blocked):
+            with clear_env():
+                with caplog.at_level(logging.ERROR, logger="synology-mcp"):
+                    result = cfg._check_windows_file_permissions(secrets_file)
+
+        assert result is False
+        assert any(
+            "pywin32 not installed" in rec.message.lower() for rec in caplog.records
+        )
+
+    def test_missing_pywin32_opt_in_returns_true(self, tmp_path, caplog):
+        """With the opt-in env var, missing pywin32 is treated as acceptable."""
+        import logging
+        import sys
+
+        secrets_file = tmp_path / "settings.json"
+        secrets_file.write_text("{}")
+
+        blocked = {
+            "win32security": None,
+            "win32api": None,
+            "ntsecuritycon": None,
+            "win32file": None,
+        }
+
+        config_mod = self._load_fresh_config()
+        cfg = config_mod.SynologyConfig.__new__(config_mod.SynologyConfig)
+
+        with patch.dict(sys.modules, blocked):
+            with clear_env(SYNOLOGY_MCP_ALLOW_UNVERIFIED_WINDOWS_ACL="true"):
+                with caplog.at_level(logging.WARNING, logger="synology-mcp"):
+                    result = cfg._check_windows_file_permissions(secrets_file)
+
+        assert result is True
+        assert any(
+            "skipped" in rec.message.lower()
+            and "allow_unverified" in rec.message.lower()
+            for rec in caplog.records
+        ) or any(
+            "allow_unverified_windows_acl=true" in rec.message.lower()
+            for rec in caplog.records
+        )
+
+    def test_owner_match_with_clean_dacl_returns_true(self, tmp_path, caplog):
+        """Owner == current user AND only allowlisted ACEs → pass."""
+        import logging
+        import sys
+
+        secrets_file = tmp_path / "settings.json"
+        secrets_file.write_text("{}")
+
+        fakes = self._build_fakes(
+            owner_sid=self.CURRENT_SID,
+            dacl_aces=[
+                self._ace(self.CURRENT_SID),
+                self._ace(self.SYSTEM_SID),
+                self._ace(self.ADMINS_SID),
+            ],
+        )
+
+        config_mod = self._load_fresh_config()
+        cfg = config_mod.SynologyConfig.__new__(config_mod.SynologyConfig)
+
+        with patch.dict(sys.modules, fakes):
             with caplog.at_level(logging.INFO, logger="synology-mcp"):
                 result = cfg._check_windows_file_permissions(secrets_file)
 
@@ -407,40 +486,22 @@ class TestWindowsAclFallback:
         )
 
     def test_owner_mismatch_returns_false(self, tmp_path, caplog):
-        """When owner SID differs from current user SID, the check fails."""
+        """Owner SID != current user → fail."""
         import logging
         import sys
-        import types
 
         secrets_file = tmp_path / "settings.json"
         secrets_file.write_text("{}")
 
-        owner_sid = "S-1-5-21-someone-else"
-        current_sid = "S-1-5-21-currentuser"
-
-        fake_win32security = types.ModuleType("win32security")
-        fake_win32security.OWNER_SECURITY_INFORMATION = 1
-        fake_win32security.TOKEN_QUERY = 8
-        fake_win32security.TokenUser = 1
-
-        def _get_file_security(_path, _info):
-            sd = types.SimpleNamespace(GetSecurityDescriptorOwner=lambda: owner_sid)
-            return sd
-
-        fake_win32security.GetFileSecurity = _get_file_security
-        fake_win32security.GetCurrentProcess = lambda: "proc"
-        fake_win32security.OpenProcessToken = lambda _p, _a: "token"
-        fake_win32security.GetTokenInformation = lambda _t, _c: {"UserSid": current_sid}
-
-        fake_win32file = types.ModuleType("win32file")
+        fakes = self._build_fakes(
+            owner_sid="S-1-5-21-someone-else",
+            dacl_aces=[self._ace(self.CURRENT_SID)],
+        )
 
         config_mod = self._load_fresh_config()
         cfg = config_mod.SynologyConfig.__new__(config_mod.SynologyConfig)
 
-        with patch.dict(
-            sys.modules,
-            {"win32security": fake_win32security, "win32file": fake_win32file},
-        ):
+        with patch.dict(sys.modules, fakes):
             with caplog.at_level(logging.WARNING, logger="synology-mcp"):
                 result = cfg._check_windows_file_permissions(secrets_file)
 
@@ -448,6 +509,89 @@ class TestWindowsAclFallback:
         assert any(
             "owner sid does not match" in rec.message.lower() for rec in caplog.records
         )
+
+    def test_null_dacl_returns_false(self, tmp_path, caplog):
+        """A NULL DACL (everyone full access) is rejected."""
+        import logging
+        import sys
+
+        secrets_file = tmp_path / "settings.json"
+        secrets_file.write_text("{}")
+
+        fakes = self._build_fakes(
+            owner_sid=self.CURRENT_SID,
+            dacl_is_null=True,
+        )
+
+        config_mod = self._load_fresh_config()
+        cfg = config_mod.SynologyConfig.__new__(config_mod.SynologyConfig)
+
+        with patch.dict(sys.modules, fakes):
+            with caplog.at_level(logging.WARNING, logger="synology-mcp"):
+                result = cfg._check_windows_file_permissions(secrets_file)
+
+        assert result is False
+        assert any(
+            "null dacl" in rec.message.lower() for rec in caplog.records
+        )
+
+    def test_foreign_allow_ace_returns_false(self, tmp_path, caplog):
+        """An allow-ACE for Everyone (outside allowlist) fails the check.
+
+        This is the core of issue #72: owner matches, but the file is still
+        readable by Everyone via an inherited ACE.
+        """
+        import logging
+        import sys
+
+        secrets_file = tmp_path / "settings.json"
+        secrets_file.write_text("{}")
+
+        fakes = self._build_fakes(
+            owner_sid=self.CURRENT_SID,
+            dacl_aces=[
+                self._ace(self.CURRENT_SID),
+                self._ace(self.EVERYONE_SID),
+            ],
+        )
+
+        config_mod = self._load_fresh_config()
+        cfg = config_mod.SynologyConfig.__new__(config_mod.SynologyConfig)
+
+        with patch.dict(sys.modules, fakes):
+            with caplog.at_level(logging.WARNING, logger="synology-mcp"):
+                result = cfg._check_windows_file_permissions(secrets_file)
+
+        assert result is False
+        assert any(
+            "outside the allowlist" in rec.message.lower() for rec in caplog.records
+        )
+
+    def test_deny_ace_does_not_fail_check(self, tmp_path, caplog):
+        """Deny-ACEs only narrow access; they must not fail the check."""
+        import logging
+        import sys
+
+        secrets_file = tmp_path / "settings.json"
+        secrets_file.write_text("{}")
+
+        fakes = self._build_fakes(
+            owner_sid=self.CURRENT_SID,
+            dacl_aces=[
+                self._ace(self.CURRENT_SID),
+                # 1 = ACCESS_DENIED_ACE_TYPE — narrowing, should be ignored.
+                self._ace(self.EVERYONE_SID, ace_type=1),
+            ],
+        )
+
+        config_mod = self._load_fresh_config()
+        cfg = config_mod.SynologyConfig.__new__(config_mod.SynologyConfig)
+
+        with patch.dict(sys.modules, fakes):
+            with caplog.at_level(logging.INFO, logger="synology-mcp"):
+                result = cfg._check_windows_file_permissions(secrets_file)
+
+        assert result is True
 
     def test_win32_runtime_failure_returns_false(self, tmp_path, caplog):
         """A runtime error from win32security fails the check (fail-closed)."""
@@ -458,27 +602,35 @@ class TestWindowsAclFallback:
         secrets_file = tmp_path / "settings.json"
         secrets_file.write_text("{}")
 
-        fake_win32security = types.ModuleType("win32security")
-        fake_win32security.OWNER_SECURITY_INFORMATION = 1
-        fake_win32security.TOKEN_QUERY = 8
-        fake_win32security.TokenUser = 1
-
         def _boom(*_args, **_kwargs):
             raise OSError("denied")
 
+        fake_win32security = types.ModuleType("win32security")
+        fake_win32security.OWNER_SECURITY_INFORMATION = 1
+        fake_win32security.DACL_SECURITY_INFORMATION = 4
+        fake_win32security.TOKEN_QUERY = 8
+        fake_win32security.TokenUser = 1
         fake_win32security.GetFileSecurity = _boom
-        fake_win32security.GetCurrentProcess = _boom
         fake_win32security.OpenProcessToken = _boom
         fake_win32security.GetTokenInformation = _boom
+        fake_win32security.LookupAccountName = _boom
 
-        fake_win32file = types.ModuleType("win32file")
+        fake_win32api = types.ModuleType("win32api")
+        fake_win32api.GetCurrentProcess = lambda: "proc"
+
+        fake_ntsecuritycon = types.ModuleType("ntsecuritycon")
+        fake_ntsecuritycon.ACCESS_ALLOWED_ACE_TYPE = 0
 
         config_mod = self._load_fresh_config()
         cfg = config_mod.SynologyConfig.__new__(config_mod.SynologyConfig)
 
         with patch.dict(
             sys.modules,
-            {"win32security": fake_win32security, "win32file": fake_win32file},
+            {
+                "win32security": fake_win32security,
+                "win32api": fake_win32api,
+                "ntsecuritycon": fake_ntsecuritycon,
+            },
         ):
             with caplog.at_level(logging.WARNING, logger="synology-mcp"):
                 result = cfg._check_windows_file_permissions(secrets_file)
@@ -490,11 +642,6 @@ class TestWindowsAclFallback:
 
     def test_dispatch_on_nt_calls_windows_check(self, tmp_path):
         """_check_file_permissions routes to the Windows check when os.name == 'nt'."""
-        import sys
-
-        secrets_file = tmp_path / "settings.json"
-        secrets_file.write_text("{}")
-
         config_mod = self._load_fresh_config()
         cfg = config_mod.SynologyConfig.__new__(config_mod.SynologyConfig)
 
@@ -503,6 +650,9 @@ class TestWindowsAclFallback:
         def _stub(_path):
             called["count"] += 1
             return True
+
+        secrets_file = tmp_path / "settings.json"
+        secrets_file.write_text("{}")
 
         with patch.object(config_mod.os, "name", "nt"):
             with patch.object(cfg, "_check_windows_file_permissions", _stub):


### PR DESCRIPTION
## Summary
- Add Windows ACL enforcement in `_check_file_permissions()` via a new `_check_windows_file_permissions()` method that uses pywin32 (`win32security`) to verify the `settings.json` owner SID matches the current user.
- Restructure `_check_file_permissions()` so the Windows branch is dispatched on `os.name == "nt"` **before** the POSIX `hasattr(os, "getuid")` guard — the previous order made the Windows check dead code.
- Treat pywin32 as an optional dependency: if it's not installed, the check is skipped with a WARNING and the file loads unverified (fail-open, matching the existing documented behaviour). Runtime errors from win32security fail-closed (return `False`).
- Document the expected Windows ACL shape and lock-down commands (`icacls`) in README, alongside the POSIX `chmod 600` guidance.
- Add `TestWindowsAclFallback` covering: pywin32-missing fallback, owner-SID match (pass), owner-SID mismatch (fail), win32 runtime error (fail-closed), and `os.name == "nt"` dispatch routing.

## Why
Issue #72: PR #66 made the test suite runnable on Windows by skipping the POSIX permission check and returning `True` ("not checked"), so `settings.json` — which contains NAS passwords, `otp_code`, `device_id`, and the Xiaozhi token — loaded without any ACL verification. This adds the missing enforcement path so Windows installs verify the file owner before loading, while keeping pywin32 optional so the package still installs cleanly on non-Windows hosts.

## Test plan
- [x] Build succeeds (`python -m py_compile src/config.py`).
- [x] `tests/test_config.py` — 17/17 pass (was 12; +5 new Windows ACL tests).
- [x] No regression in the rest of the suite (pre-existing logout/validate_config failures reproduce on unmodified `main`).
- [ ] Manual verification on a Windows host with pywin32 installed (owner-SID match → loads; mismatch → refused).

Closes #72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform-specific security checks for configuration file ownership and permissions.
  * Windows checks now validate ownership and access controls, with safe handling when optional verification support is unavailable.
* **Documentation**
  * Added guidance for securing and verifying configuration file permissions on Linux, macOS, and Windows.
  * Included platform-specific remediation commands and expected permission restrictions.
* **Bug Fixes**
  * Improved handling of failed or mismatched permission checks to prevent insecure configurations from being accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->