### PR TITLE
feat: add iSCSI LUN list/get tools (SYNO.Core.ISCSI.LUN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,9 @@ docker-compose up
 - **`synology_disk_smart`** - Get detailed SMART attributes for a specific disk
 - **`synology_volume_status`** - List all volumes with status, size, usage, filesystem type
 - **`synology_storage_pool`** - List RAID/storage pools with level, status, member disks
+- **`synology_lun_list`** - List all iSCSI LUNs with name, UUID, size, usage, status, and mapped targets
+- **`synology_lun_get`** - Get details for a single iSCSI LUN
+  - `name` (required): LUN name or UUID from `synology_lun_list` output
 - **`synology_network`** - Get network interface status and transfer rates
 - **`synology_ups`** - Get UPS status, battery level, power readings
 - **`synology_services`** - List installed packages and their running status

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ docker-compose up
 - **`synology_disk_smart`** - Get detailed SMART attributes for a specific disk
 - **`synology_volume_status`** - List all volumes with status, size, usage, filesystem type
 - **`synology_storage_pool`** - List RAID/storage pools with level, status, member disks
-- **`synology_lun_list`** - List all iSCSI LUNs with name, UUID, size, usage, status, and mapped targets
+- **`synology_lun_list`** - List all iSCSI LUNs with name, UUID, size, usage, status, mapped targets, and backing volume
 - **`synology_lun_get`** - Get details for a single iSCSI LUN
   - `name` (required): LUN name or UUID from `synology_lun_list` output
 - **`synology_network`** - Get network interface status and transfer rates

--- a/src/health/synology_health.py
+++ b/src/health/synology_health.py
@@ -140,6 +140,36 @@ class SynologyHealth:
         return storage
 
     # ------------------------------------------------------------------
+    # iSCSI LUNs
+    # ------------------------------------------------------------------
+
+    def lun_list(self) -> Dict[str, Any]:
+        """List all iSCSI LUNs with name, UUID, size, usage, status, target mappings."""
+        return self._api_call("SYNO.Core.ISCSI.LUN", "list")
+
+    def lun_get(self, name_or_uuid: str) -> Dict[str, Any]:
+        """Get a single iSCSI LUN by name or UUID.
+
+        The LUN list response already carries the full LUN objects, so a
+        single LUN is resolved client-side by matching either the `name` or
+        `uuid` field — no extra API round-trip beyond the list call.
+        """
+        result = self.lun_list()
+        if not result.get("success"):
+            return result
+        luns = result.get("data", {}).get("luns", []) or []
+        for lun in luns:
+            if name_or_uuid in (lun.get("name"), lun.get("uuid")):
+                return {"success": True, "data": lun}
+        return {
+            "success": False,
+            "error": {
+                "code": "lun_not_found",
+                "message": f"No iSCSI LUN found matching '{name_or_uuid}'",
+            },
+        }
+
+    # ------------------------------------------------------------------
     # Network
     # ------------------------------------------------------------------
 

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -187,6 +187,8 @@ class SynologyMCPServer:
         self._register_tool("synology_disk_smart", "Get detailed S.M.A.R.T. attributes for a specific physical disk", TN_PR({"disk_id": {"type": "string", "description": "Disk identifier from synology_disk_health output — either the disk id (e.g. \'sata1\', \'sda\', \'nvme0n1\') or its device path (e.g. \'/dev/sata1\')"}}, ["disk_id"]), self._handle_disk_smart)
         self._register_tool("synology_volume_status", "List all volumes/filesystems with status, total size, used space, and RAID info", TN, partial(self._handle_health_call, method_name="volume_list"))
         self._register_tool("synology_storage_pool", "List RAID/storage pools with RAID level, status, and member disks", TN, partial(self._handle_health_call, method_name="storage_pool_list"))
+        self._register_tool("synology_lun_list", "List all iSCSI LUNs with name, UUID, size, used space, status, mapped targets, and backing volume", TN, partial(self._handle_health_call, method_name="lun_list"))
+        self._register_tool("synology_lun_get", "Get details for a single iSCSI LUN by name or UUID", TN_PR({"name": {"type": "string", "description": "LUN name or UUID from synology_lun_list output"}}, ["name"]), self._handle_lun_get)
         self._register_tool("synology_network", "Get network interface status and transfer rates", TN, partial(self._handle_health_call, method_name="network_info"))
         self._register_tool("synology_ups", "Get UPS (uninterruptible power supply) status, battery level, and power info", TN, partial(self._handle_health_call, method_name="ups_info"))
         self._register_tool("synology_services", "List installed packages/services and their running status", TN, partial(self._handle_health_call, method_name="package_list"))
@@ -1057,6 +1059,14 @@ class SynologyMCPServer:
         disk_id = arguments["disk_id"]
         health = self._get_health(base_url)
         result = health.disk_smart_info(disk_id)
+        return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+
+    async def _handle_lun_get(self, arguments: dict) -> list[types.TextContent]:
+        """Handle getting details for a single iSCSI LUN."""
+        base_url = self._get_base_url(arguments)
+        name = arguments["name"]
+        health = self._get_health(base_url)
+        result = health.lun_get(name)
         return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
 
     async def _handle_system_log(self, arguments: dict) -> list[types.TextContent]:

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -108,6 +108,56 @@ class TestSynologyHealth:
         else:
             print(f"⚠️  Storage pool list failed: {result.get('error')}")
 
+    def test_lun_list(self, session_info):
+        """Test listing iSCSI LUNs."""
+        from health.synology_health import SynologyHealth
+
+        health = SynologyHealth(
+            session_info["base_url"],
+            session_info["session_id"],
+            syno_token=session_info.get("syno_token"),
+        )
+
+        result = health.lun_list()
+
+        assert isinstance(result, dict)
+        if result.get("success"):
+            luns = result.get("data", {}).get("luns", [])
+            print(f"✅ Found {len(luns)} iSCSI LUN(s)")
+            for lun in luns:
+                print(f"   - {lun.get('name', 'unknown')}: {lun.get('status', 'unknown')}")
+        else:
+            print(f"⚠️  LUN list failed: {result.get('error')}")
+
+    def test_lun_get(self, session_info):
+        """Test getting a single iSCSI LUN by name (uses the live LUN list)."""
+        from health.synology_health import SynologyHealth
+
+        health = SynologyHealth(
+            session_info["base_url"],
+            session_info["session_id"],
+            syno_token=session_info.get("syno_token"),
+        )
+
+        listed = health.lun_list()
+        assert isinstance(listed, dict)
+        if not listed.get("success"):
+            print(f"⚠️  LUN list failed: {listed.get('error')}")
+            return
+        luns = listed.get("data", {}).get("luns", [])
+        if not luns:
+            print("⚠️  No iSCSI LUNs configured on this NAS — nothing to fetch")
+            return
+
+        result = health.lun_get(luns[0]["name"])
+
+        assert isinstance(result, dict)
+        if result.get("success"):
+            print(f"✅ LUN detail retrieved for {luns[0]['name']}")
+            assert result["data"].get("name") == luns[0]["name"]
+        else:
+            print(f"⚠️  LUN get failed: {result.get('error')}")
+
     def test_network_info(self, session_info):
         """Test getting network information."""
         from health.synology_health import SynologyHealth
@@ -327,6 +377,93 @@ class TestDiskSmartInfo:
         with patch.object(health._api, "get", side_effect=side_effect):
             result = health.disk_smart_info("usb1")
         assert result == retry_fail
+
+
+class TestLunList:
+    """Unit tests for lun_list API coordinates (no live NAS required)."""
+
+    LUN_LIST_OK = {
+        "success": True,
+        "data": {
+            "luns": [
+                {"name": "LUN-1", "uuid": "abc-123", "size": 107374182400, "status": "normal"},
+                {"name": "LUN-2", "uuid": "def-456", "size": 214748364800, "status": "normal"},
+            ],
+            "total": 2,
+        },
+    }
+
+    def _make_health(self):
+        from health.synology_health import SynologyHealth
+
+        return SynologyHealth("http://nas:5000", "fake-sid", verify_ssl=False)
+
+    def test_queries_iscsi_lun_api(self):
+        """Uses SYNO.Core.ISCSI.LUN/list."""
+        health = self._make_health()
+        with patch.object(health._api, "get", return_value=self.LUN_LIST_OK) as mock_get:
+            result = health.lun_list()
+        assert result == self.LUN_LIST_OK
+        mock_get.assert_called_once_with("SYNO.Core.ISCSI.LUN", "list", 1, None)
+
+    def test_failure_propagates(self):
+        """A failed list call is returned unchanged."""
+        health = self._make_health()
+        fail = {"success": False, "error": {"code": 105}}
+        with patch.object(health._api, "get", return_value=fail):
+            result = health.lun_list()
+        assert result == fail
+
+
+class TestLunGet:
+    """Unit tests for lun_get name/UUID resolution (no live NAS required)."""
+
+    LUN_LIST_OK = TestLunList.LUN_LIST_OK
+
+    def _make_health(self):
+        from health.synology_health import SynologyHealth
+
+        return SynologyHealth("http://nas:5000", "fake-sid", verify_ssl=False)
+
+    def test_matches_by_name(self):
+        """Returns the single LUN object when the name matches."""
+        health = self._make_health()
+        with patch.object(health._api, "get", return_value=self.LUN_LIST_OK):
+            result = health.lun_get("LUN-2")
+        assert result == {"success": True, "data": self.LUN_LIST_OK["data"]["luns"][1]}
+
+    def test_matches_by_uuid(self):
+        """The same lookup works on the UUID field."""
+        health = self._make_health()
+        with patch.object(health._api, "get", return_value=self.LUN_LIST_OK):
+            result = health.lun_get("abc-123")
+        assert result == {"success": True, "data": self.LUN_LIST_OK["data"]["luns"][0]}
+
+    def test_not_found(self):
+        """An unknown name/UUID yields a lun_not_found error."""
+        health = self._make_health()
+        with patch.object(health._api, "get", return_value=self.LUN_LIST_OK):
+            result = health.lun_get("no-such-lun")
+        assert not result.get("success")
+        assert result["error"]["code"] == "lun_not_found"
+
+    def test_list_failure_propagates(self):
+        """When the underlying list call fails, its error is the answer."""
+        health = self._make_health()
+        fail = {"success": False, "error": {"code": 119}}
+        with patch.object(health._api, "get", return_value=fail):
+            result = health.lun_get("LUN-1")
+        assert result == fail
+
+    def test_empty_lun_list(self):
+        """A successful list with no LUNs resolves to lun_not_found."""
+        health = self._make_health()
+        with patch.object(
+            health._api, "get", return_value={"success": True, "data": {"luns": [], "total": 0}}
+        ):
+            result = health.lun_get("LUN-1")
+        assert not result.get("success")
+        assert result["error"]["code"] == "lun_not_found"
 
 
 def test_health_url_construction():

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -146,8 +146,7 @@ class TestSynologyHealth:
             return
         luns = listed.get("data", {}).get("luns", [])
         if not luns:
-            print("⚠️  No iSCSI LUNs configured on this NAS — nothing to fetch")
-            return
+            pytest.skip("No iSCSI LUNs configured on this NAS — nothing to fetch")
 
         result = health.lun_get(luns[0]["name"])
 


### PR DESCRIPTION
## Summary
- Adds `synology_lun_list` — lists all iSCSI LUNs via `SYNO.Core.ISCSI.LUN/list` (name, UUID, size, used space, status, mapped targets, backing volume), selectable by `nas_name`/`base_url`.
- Adds `synology_lun_get` — detail for a single LUN by name or UUID. The list response already carries the full LUN objects, so the single-LUN lookup resolves client-side against the `name`/`uuid` fields (no extra API round-trip).
- Both mirror the existing read-only `synology_volume_status` / `synology_storage_pool` pattern: methods on `SynologyHealth`, dispatched via the health handler, with a `_handle_lun_get` handler for the parameterized call.

## Why
Issue #64: the server exposes volume and storage-pool tools but nothing for iSCSI LUNs, so there's no way to audit/manage LUNs configured in Storage Manager > iSCSI LUN via MCP.

## Test plan
- [x] `py_compile` passes on all changed files.
- [x] Unit tests added mirroring the `TestDiskSmartInfo` pattern: API coordinates for `lun_list`, name/UUID matching, not-found, list-failure propagation, empty-list (7 new tests).
- [x] Live-NAS tests added under `real_nas` marker (auto-skip without credentials), mirroring `test_volume_list`.
- [x] Full suite: 127 passed, 3 skipped (`pytest -m "not real_nas and not destructive and not slow"`).
- [x] ruff/black/mypy: no new findings — the 5 ruff N806s and the black reformat in `src/mcp_server.py` are pre-existing on `origin/main` (verified by stash comparison) and left untouched to keep this diff minimal.
- [ ] Live verification against a NAS with configured LUNs (no iSCSI target available in this environment).

Note: 4 tests in `tests/test_logout.py` fail identically on `origin/main` (logout cache-clearing assertions) — pre-existing and unrelated to this change; left as-is rather than bundled into this PR.

Closes #64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added iSCSI LUN health monitoring.
  - View all available LUNs.
  - Retrieve detailed health information using a LUN name or UUID.
  - Receive a clear response when a requested LUN cannot be found.

- **Documentation**
  - Added usage documentation for the new LUN monitoring capabilities.

- **Tests**
  - Added coverage for successful lookups, empty results, API failures, and missing LUNs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->