### PR TITLE
feat: add container health and disk usage summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 - Per-NAS `url` key in `settings.json`: when present it is used verbatim (trailing slash stripped) and wins over `host`/`port`, so a NAS published through a reverse proxy on the default 443 — whose URL carries no port — can finally be addressed. Non-string values are rejected with a warning and skip only that entry. (#76)
-- `synology_container_image_prune` for safe Docker image-only cleanup. It preserves containers and networks, uses an explicitly configured SSH Docker CLI fallback when DSM cannot prune dangling layers, and reports API-only exclusions without pretending they were deleted.
+- `synology_container_image_prune` for safe Docker image-only cleanup through Container Manager APIs. It preserves containers and networks and reports dangling images that DSM cannot safely delete without pretending they were deleted.
 
 ### Fixed
 - `list_directory` and `get_file_info` reported **every file as 0 bytes**. DSM returns the byte count inside the entry's `additional` block (which is where we ask for the `size` field), but both handlers only read a top-level `size` key that DSM never populates. Sizes are now read from `additional.size`, falling back to the top-level key for API versions that inline it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Per-NAS `url` key in `settings.json`: when present it is used verbatim (trailing slash stripped) and wins over `host`/`port`, so a NAS published through a reverse proxy on the default 443 — whose URL carries no port — can finally be addressed. Non-string values are rejected with a warning and skip only that entry. (#76)
+- `synology_container_image_prune` for safe Docker image-only cleanup. It preserves containers and networks, uses an explicitly configured SSH Docker CLI fallback when DSM cannot prune dangling layers, and reports API-only exclusions without pretending they were deleted.
 
 ### Fixed
 - `list_directory` and `get_file_info` reported **every file as 0 bytes**. DSM returns the byte count inside the entry's `additional` block (which is where we ask for the `size` field), but both handlers only read a top-level `size` key that DSM never populates. Sizes are now read from `additional.size`, falling back to the top-level key for API versions that inline it.

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ WORKDIR /app
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     gcc \
-    openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements first for better caching

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     gcc \
+    openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements first for better caching

--- a/README.md
+++ b/README.md
@@ -377,11 +377,11 @@ docker-compose up
 
 ### 🐳 Container Manager
 - **`synology_container_list`** - List Container Manager containers
-- **`synology_container_health_summary`** - Summarize container status, health, restart counts, and images
-- **`synology_container_disk_usage`** - Show Docker disk usage through the read-only SSH CLI
   - `offset` (optional): Pagination offset
   - `limit` (optional): Maximum containers to return
   - `container_type` (optional): Container filter (default: `all`)
+- **`synology_container_health_summary`** - Summarize container status, health, restart counts, and images
+- **`synology_container_disk_usage`** - Show Docker disk usage through the read-only SSH CLI
 - **`synology_container_get`** - Get a Container Manager container
   - `name` (required): Container name
 - **`synology_container_start`** - Start a Container Manager container
@@ -443,7 +443,7 @@ docker-compose up
   - `tag` (optional): Image tag (default: `latest`)
 - **`synology_container_image_prune`** - Remove images unused by any container
   - **`synology_container_image_prune_preview`** provides a read-only candidate list before cleanup
-  - Uses Docker's image-only prune only when explicit `ssh_username`, `ssh_password`, and a provisioned `ssh_known_hosts` path are configured for the exact NAS URL
+  - Selects Docker's image-only SSH prune when explicit `ssh_username`, `ssh_password`, and a provisioned `ssh_known_hosts` path are configured for the exact NAS URL
   - The API-only fallback deletes safely identifiable unused tagged images and reports dangling images it could not remove
   - Does not remove containers, networks, or build cache
 - **`synology_container_image_pull`** - Pull a Container Manager image

--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ docker-compose up
   - `tag` (optional): Image tag (default: `latest`)
 - **`synology_container_image_prune`** - Remove images unused by any container
   - **`synology_container_image_prune_preview`** provides a read-only candidate list before cleanup
-  - Uses Docker's image-only prune over explicitly configured SSH when DSM's image API cannot prune dangling layers
+  - Uses Docker's image-only prune only when explicit `ssh_username`, `ssh_password`, and a provisioned `ssh_known_hosts` path are configured for the exact NAS URL
   - The API-only fallback deletes safely identifiable unused tagged images and reports dangling images it could not remove
   - Does not remove containers, networks, or build cache
 - **`synology_container_image_pull`** - Pull a Container Manager image

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ docker-compose up
   - `limit` (optional): Maximum containers to return
   - `container_type` (optional): Container filter (default: `all`)
 - **`synology_container_health_summary`** - Summarize container status, health, restart counts, and images
-- **`synology_container_disk_usage`** - Show Docker disk usage through the read-only SSH CLI
+- **`synology_container_disk_usage`** - Show the read-only disk-usage summary available through Container Manager APIs
 - **`synology_container_get`** - Get a Container Manager container
   - `name` (required): Container name
 - **`synology_container_start`** - Start a Container Manager container
@@ -443,8 +443,7 @@ docker-compose up
   - `tag` (optional): Image tag (default: `latest`)
 - **`synology_container_image_prune`** - Remove images unused by any container
   - **`synology_container_image_prune_preview`** provides a read-only candidate list before cleanup
-  - Selects Docker's image-only SSH prune when explicit `ssh_username`, `ssh_password`, and a provisioned `ssh_known_hosts` path are configured for the exact NAS URL
-  - The API-only fallback deletes safely identifiable unused tagged images and reports dangling images it could not remove
+  - Uses only Container Manager APIs to delete safely identifiable unused tagged images and reports dangling images it cannot remove through DSM
   - Does not remove containers, networks, or build cache
 - **`synology_container_image_pull`** - Pull a Container Manager image
   - `repository` (required): Image repository name

--- a/README.md
+++ b/README.md
@@ -377,6 +377,8 @@ docker-compose up
 
 ### 🐳 Container Manager
 - **`synology_container_list`** - List Container Manager containers
+- **`synology_container_health_summary`** - Summarize container status, health, restart counts, and images
+- **`synology_container_disk_usage`** - Show Docker disk usage through the read-only SSH CLI
   - `offset` (optional): Pagination offset
   - `limit` (optional): Maximum containers to return
   - `container_type` (optional): Container filter (default: `all`)

--- a/README.md
+++ b/README.md
@@ -439,6 +439,11 @@ docker-compose up
 - **`synology_container_image_delete`** - Delete a Container Manager image
   - `name` (required): Image repository name
   - `tag` (optional): Image tag (default: `latest`)
+- **`synology_container_image_prune`** - Remove images unused by any container
+  - **`synology_container_image_prune_preview`** provides a read-only candidate list before cleanup
+  - Uses Docker's image-only prune over explicitly configured SSH when DSM's image API cannot prune dangling layers
+  - The API-only fallback deletes safely identifiable unused tagged images and reports dangling images it could not remove
+  - Does not remove containers, networks, or build cache
 - **`synology_container_image_pull`** - Pull a Container Manager image
   - `repository` (required): Image repository name
   - `tag` (optional): Image tag (default: `latest`)

--- a/src/config.py
+++ b/src/config.py
@@ -104,6 +104,9 @@ class SynologyConfig:
         self.synology_url = os.getenv("SYNOLOGY_URL")
         self.synology_username = os.getenv("SYNOLOGY_USERNAME")
         self.synology_password = os.getenv("SYNOLOGY_PASSWORD")
+        self.synology_ssh_username = os.getenv("SYNOLOGY_SSH_USERNAME")
+        self.synology_ssh_password = os.getenv("SYNOLOGY_SSH_PASSWORD")
+        self.synology_ssh_known_hosts = os.getenv("SYNOLOGY_SSH_KNOWN_HOSTS")
         # One-shot 2FA code for legacy .env single-NAS users on first login.
         # Settings.json users store `device_id` per-NAS for ongoing reuse and
         # don't need this. Read-only here; auto-login consumes it but does
@@ -442,6 +445,9 @@ class SynologyConfig:
                     port = nas_info.get("port", 5000)
                     username = nas_info.get("username", "")
                     password = nas_info.get("password", "")
+                    ssh_username = nas_info.get("ssh_username")
+                    ssh_password = nas_info.get("ssh_password")
+                    ssh_known_hosts = nas_info.get("ssh_known_hosts")
                     # Optional 2FA/OTP support (DSM Login Web API Guide):
                     #   - `otp_code`: one-shot code from authenticator. Needed
                     #     only on the FIRST login after enabling 2FA on the
@@ -494,6 +500,9 @@ class SynologyConfig:
                         "base_url": base_url,
                         "username": username,
                         "password": password,
+                        "ssh_username": ssh_username,
+                        "ssh_password": ssh_password,
+                        "ssh_known_hosts": ssh_known_hosts,
                         "verify_ssl": nas_verify_ssl,
                         "note": nas_info.get("note", ""),
                         "otp_code": otp_code,
@@ -543,12 +552,24 @@ class SynologyConfig:
         return self.verify_ssl
 
     def credentials_for(self, base_url: str) -> tuple[Optional[str], Optional[str]]:
-        """Return the configured username/password for a NAS URL."""
+        """Return the configured DSM username/password for an exact NAS URL."""
         target = self._normalize_base_url(base_url)
         for cfg in self.nas_configs.values():
-            if self._normalize_base_url(cfg.get("base_url", "")) == target:
+            if cfg.get("base_url") and self._normalize_base_url(cfg["base_url"]) == target:
                 return cfg.get("username"), cfg.get("password")
-        return self.synology_username, self.synology_password
+        if self.synology_url and self._normalize_base_url(self.synology_url) == target:
+            return self.synology_username, self.synology_password
+        return None, None
+
+    def ssh_credentials_for(self, base_url: str) -> tuple[Optional[str], Optional[str], Optional[str]]:
+        """Return explicit SSH credentials and known-hosts path for a NAS URL."""
+        target = self._normalize_base_url(base_url)
+        for cfg in self.nas_configs.values():
+            if cfg.get("base_url") and self._normalize_base_url(cfg["base_url"]) == target:
+                return cfg.get("ssh_username"), cfg.get("ssh_password"), cfg.get("ssh_known_hosts")
+        if self.synology_url and self._normalize_base_url(self.synology_url) == target:
+            return self.synology_ssh_username, self.synology_ssh_password, self.synology_ssh_known_hosts
+        return None, None, None
 
     @staticmethod
     def _normalize_base_url(url: str) -> str:
@@ -618,6 +639,9 @@ class SynologyConfig:
             "base_url": self.synology_url,
             "username": self.synology_username,
             "password": self.synology_password,
+            "ssh_username": self.synology_ssh_username,
+            "ssh_password": self.synology_ssh_password,
+            "ssh_known_hosts": self.synology_ssh_known_hosts,
             "verify_ssl": self.verify_ssl,
             "otp_code": self.synology_otp_code,
             "device_id": None,

--- a/src/config.py
+++ b/src/config.py
@@ -545,18 +545,6 @@ class SynologyConfig:
                 return cfg.get("verify_ssl", self.verify_ssl)
         return self.verify_ssl
 
-    def credentials_for(self, base_url: str) -> tuple[Optional[str], Optional[str]]:
-        """Return the configured DSM username/password for an exact NAS URL."""
-        target = self._normalize_base_url(base_url)
-        for cfg in self.nas_configs.values():
-            if cfg.get("base_url") and self._normalize_base_url(cfg["base_url"]) == target:
-                return cfg.get("username"), cfg.get("password")
-        if self.synology_url and self._normalize_base_url(self.synology_url) == target:
-            return self.synology_username, self.synology_password
-        return None, None
-
-
-
     @staticmethod
     def _normalize_base_url(url: str) -> str:
         """Canonicalize a base URL for identity comparison.

--- a/src/config.py
+++ b/src/config.py
@@ -542,6 +542,14 @@ class SynologyConfig:
                 return cfg.get("verify_ssl", self.verify_ssl)
         return self.verify_ssl
 
+    def credentials_for(self, base_url: str) -> tuple[Optional[str], Optional[str]]:
+        """Return the configured username/password for a NAS URL."""
+        target = self._normalize_base_url(base_url)
+        for cfg in self.nas_configs.values():
+            if self._normalize_base_url(cfg.get("base_url", "")) == target:
+                return cfg.get("username"), cfg.get("password")
+        return self.synology_username, self.synology_password
+
     @staticmethod
     def _normalize_base_url(url: str) -> str:
         """Canonicalize a base URL for identity comparison.

--- a/src/config.py
+++ b/src/config.py
@@ -104,9 +104,7 @@ class SynologyConfig:
         self.synology_url = os.getenv("SYNOLOGY_URL")
         self.synology_username = os.getenv("SYNOLOGY_USERNAME")
         self.synology_password = os.getenv("SYNOLOGY_PASSWORD")
-        self.synology_ssh_username = os.getenv("SYNOLOGY_SSH_USERNAME")
-        self.synology_ssh_password = os.getenv("SYNOLOGY_SSH_PASSWORD")
-        self.synology_ssh_known_hosts = os.getenv("SYNOLOGY_SSH_KNOWN_HOSTS")
+
         # One-shot 2FA code for legacy .env single-NAS users on first login.
         # Settings.json users store `device_id` per-NAS for ongoing reuse and
         # don't need this. Read-only here; auto-login consumes it but does
@@ -445,9 +443,7 @@ class SynologyConfig:
                     port = nas_info.get("port", 5000)
                     username = nas_info.get("username", "")
                     password = nas_info.get("password", "")
-                    ssh_username = nas_info.get("ssh_username")
-                    ssh_password = nas_info.get("ssh_password")
-                    ssh_known_hosts = nas_info.get("ssh_known_hosts")
+
                     # Optional 2FA/OTP support (DSM Login Web API Guide):
                     #   - `otp_code`: one-shot code from authenticator. Needed
                     #     only on the FIRST login after enabling 2FA on the
@@ -500,9 +496,7 @@ class SynologyConfig:
                         "base_url": base_url,
                         "username": username,
                         "password": password,
-                        "ssh_username": ssh_username,
-                        "ssh_password": ssh_password,
-                        "ssh_known_hosts": ssh_known_hosts,
+
                         "verify_ssl": nas_verify_ssl,
                         "note": nas_info.get("note", ""),
                         "otp_code": otp_code,
@@ -561,15 +555,7 @@ class SynologyConfig:
             return self.synology_username, self.synology_password
         return None, None
 
-    def ssh_credentials_for(self, base_url: str) -> tuple[Optional[str], Optional[str], Optional[str]]:
-        """Return explicit SSH credentials and known-hosts path for a NAS URL."""
-        target = self._normalize_base_url(base_url)
-        for cfg in self.nas_configs.values():
-            if cfg.get("base_url") and self._normalize_base_url(cfg["base_url"]) == target:
-                return cfg.get("ssh_username"), cfg.get("ssh_password"), cfg.get("ssh_known_hosts")
-        if self.synology_url and self._normalize_base_url(self.synology_url) == target:
-            return self.synology_ssh_username, self.synology_ssh_password, self.synology_ssh_known_hosts
-        return None, None, None
+
 
     @staticmethod
     def _normalize_base_url(url: str) -> str:
@@ -639,9 +625,7 @@ class SynologyConfig:
             "base_url": self.synology_url,
             "username": self.synology_username,
             "password": self.synology_password,
-            "ssh_username": self.synology_ssh_username,
-            "ssh_password": self.synology_ssh_password,
-            "ssh_known_hosts": self.synology_ssh_known_hosts,
+
             "verify_ssl": self.verify_ssl,
             "otp_code": self.synology_otp_code,
             "device_id": None,

--- a/src/container/synology_container.py
+++ b/src/container/synology_container.py
@@ -22,10 +22,12 @@ class SynologyContainer:
         syno_token: Optional[str] = None,
         ssh_username: Optional[str] = None,
         ssh_password: Optional[str] = None,
+        ssh_known_hosts: Optional[str] = None,
     ):
         self._api = SynologyAPIClient(base_url, session_id, verify_ssl, syno_token=syno_token)
         self._ssh_username = ssh_username
         self._ssh_password = ssh_password
+        self._ssh_known_hosts = ssh_known_hosts
         self.container_api = "SYNO.Docker.Container"
         self.container_version = 1
         self.project_api = "SYNO.Docker.Project"
@@ -327,9 +329,12 @@ class SynologyContainer:
         containers = self.list_containers(offset=0, limit=-1, container_type="all")
         if not containers.get("success"):
             return containers
-        container_data = containers.get("data", {})
-        container_items = container_data.get("containers", []) if isinstance(container_data, dict) else []
+        container_data = containers.get("data")
+        if not isinstance(container_data, dict) or not isinstance(container_data.get("containers"), list):
+            return {"success": False, "error": {"code": "unsafe_prune", "message": "Unexpected container inventory; no images were deleted"}}
+        container_items = container_data["containers"]
         references = set()
+        digest_repositories = set()
         for item in container_items:
             if not isinstance(item, dict) or not item.get("image"):
                 return {
@@ -342,7 +347,7 @@ class SynologyContainer:
             image = str(item["image"])
             references.add(image)
             if "@" in image:
-                references.add(image.split("@", 1)[0])
+                digest_repositories.add(image.split("@", 1)[0])
 
         images_result = self.list_images(offset=0, limit=-1)
         if not images_result.get("success"):
@@ -369,7 +374,7 @@ class SynologyContainer:
                     # for the Docker CLI fallback rather than reporting a
                     # misleading deletion attempt.
                     skipped.append(full_name)
-                elif full_name not in references:
+                elif full_name not in references and image["repository"] not in digest_repositories:
                     candidates.append((full_name, image))
 
         if dry_run:
@@ -412,6 +417,11 @@ class SynologyContainer:
         host = urlsplit(self._api.base_url).hostname
         if not host:
             return {"success": False, "error": {"code": "invalid_host", "message": "NAS URL has no hostname"}}
+        if not self._ssh_username or not self._ssh_password:
+            return {"success": False, "error": {"code": "ssh_credentials_unavailable", "message": "Explicit SSH credentials are required"}}
+        if not self._ssh_known_hosts:
+            return {"success": False, "error": {"code": "ssh_known_hosts_unavailable", "message": "A provisioned SSH known_hosts file is required"}}
+
 
         askpass_fd, askpass = tempfile.mkstemp(prefix="synology-mcp-askpass-")
         os.close(askpass_fd)
@@ -432,9 +442,9 @@ class SynologyContainer:
             )
             result = subprocess.run(
                 [
-                    "setsid", "ssh", "-o", "BatchMode=no", "-o", "ConnectTimeout=20",
+                    "/usr/bin/setsid", "/usr/bin/ssh", "-o", "BatchMode=no", "-o", "ConnectTimeout=20",
                     "-o", "PreferredAuthentications=password", "-o", "PubkeyAuthentication=no",
-                    "-o", "StrictHostKeyChecking=accept-new", f"{self._ssh_username}@{host}", command,
+                    "-o", "StrictHostKeyChecking=yes", "-o", f"UserKnownHostsFile={self._ssh_known_hosts}", f"{self._ssh_username}@{host}", command,
                 ],
                 capture_output=True, text=True, timeout=300, env=env, check=False,
             )

--- a/src/container/synology_container.py
+++ b/src/container/synology_container.py
@@ -76,6 +76,20 @@ class SynologyContainer:
             type=container_type,
         )
 
+    def health_summary(self) -> Dict[str, Any]:
+        """Return a compact health summary for every container."""
+        result = self.list_containers(offset=0, limit=-1, container_type="all")
+        if not result.get("success"):
+            return result
+        data = result.get("data", {})
+        items = data.get("containers", []) if isinstance(data, dict) else []
+        summary = [{"name": i.get("name"), "status": i.get("status", i.get("state")), "health": i.get("health"), "restart_count": i.get("restartCount", i.get("restart_count", 0)), "image": i.get("image")} for i in items if isinstance(i, dict)]
+        return {"success": True, "data": {"containers": summary, "count": len(summary)}}
+
+    def disk_usage(self) -> Dict[str, Any]:
+        """Return Docker disk usage using the read-only SSH CLI."""
+        return self._ssh_docker_command("system df", "docker_disk_usage_failed", "Docker disk usage timed out")
+
     def get_container(self, name: str) -> Dict[str, Any]:
         """Get one Container Manager container by name."""
         return self._container_name_request("get", name)
@@ -414,6 +428,10 @@ class SynologyContainer:
 
     def _ssh_docker_prune(self) -> Dict[str, Any]:
         """Run Docker's image-only prune through the authorized SSH account."""
+        return self._ssh_docker_command("image prune --all --force", "ssh_prune_failed", "Docker prune timed out")
+
+    def _ssh_docker_command(self, docker_command: str, error_code: str, timeout_message: str) -> Dict[str, Any]:
+        """Run a fixed Docker command through the explicitly configured SSH account."""
         host = urlsplit(self._api.base_url).hostname
         if not host:
             return {"success": False, "error": {"code": "invalid_host", "message": "NAS URL has no hostname"}}
@@ -422,6 +440,9 @@ class SynologyContainer:
         if not self._ssh_known_hosts:
             return {"success": False, "error": {"code": "ssh_known_hosts_unavailable", "message": "A provisioned SSH known_hosts file is required"}}
 
+
+        if docker_command not in {"image prune --all --force", "system df"}:
+            return {"success": False, "error": {"code": "unsupported_ssh_command", "message": "Unsupported Docker command"}}
 
         askpass_fd, askpass = tempfile.mkstemp(prefix="synology-mcp-askpass-")
         os.close(askpass_fd)
@@ -436,10 +457,7 @@ class SynologyContainer:
                 "SSH_ASKPASS_REQUIRE": "force",
                 "DISPLAY": "synology-mcp",
             })
-            command = (
-                "sudo -n /var/packages/ContainerManager/target/usr/bin/docker "
-                "image prune --all --force"
-            )
+            command = "sudo -n /var/packages/ContainerManager/target/usr/bin/docker " + docker_command
             result = subprocess.run(
                 [
                     "/usr/bin/setsid", "/usr/bin/ssh", "-o", "BatchMode=no", "-o", "ConnectTimeout=20",
@@ -451,7 +469,7 @@ class SynologyContainer:
         except FileNotFoundError as exc:
             return {"success": False, "error": {"code": "ssh_unavailable", "message": str(exc)}}
         except subprocess.TimeoutExpired:
-            return {"success": False, "error": {"code": "ssh_timeout", "message": "Docker prune timed out"}}
+            return {"success": False, "error": {"code": "ssh_timeout", "message": timeout_message}}
         finally:
             try:
                 os.unlink(askpass)
@@ -460,8 +478,11 @@ class SynologyContainer:
 
         output = (result.stdout or "").strip()
         if result.returncode:
-            return {"success": False, "error": {"code": "ssh_prune_failed", "message": (result.stderr or output).strip()[-2000:]}}
-        return {"success": True, "data": {"mode": "ssh", "output": output}}
+            return {"success": False, "error": {"code": error_code, "message": (result.stderr or output).strip()[-2000:]}}
+        data = {"mode": "ssh", "output": output}
+        if docker_command == "system df":
+            data["command"] = docker_command
+        return {"success": True, "data": data}
 
     def pull_image(self, repository: str, tag: str = "latest") -> Dict[str, Any]:
         """Pull a Container Manager image from a registry."""

--- a/src/container/synology_container.py
+++ b/src/container/synology_container.py
@@ -2,6 +2,7 @@
 
 import json
 import re
+from decimal import Decimal, InvalidOperation
 from typing import Any, Dict, Optional
 
 
@@ -19,11 +20,8 @@ def _canonical_image_reference(reference: str) -> tuple[str, Optional[str], Opti
     name, separator, digest = reference.partition("@")
     if separator and (not digest or not _DIGEST_RE.fullmatch(digest)):
         raise ValueError("invalid image digest")
-    if "@" in digest:
-        raise ValueError("invalid image reference")
-
     last = name.rsplit("/", 1)[-1]
-    tag = None
+    tag: Optional[str] = None
     if ":" in last:
         repository, tag = name.rsplit(":", 1)
         if not tag:
@@ -42,11 +40,25 @@ def _canonical_image_reference(reference: str) -> tuple[str, Optional[str], Opti
     if components[0] == "docker.io" and len(components) == 2:
         components.insert(1, "library")
     normalized_repository = "/".join(components).lower()
-    return normalized_repository, tag or "latest" if not separator else None, digest or None
+    normalized_tag = None if separator else (tag or "latest")
+    return normalized_repository, normalized_tag, digest or None
 
 
 def _unsafe_prune_result(message: str) -> Dict[str, Any]:
     return {"success": False, "error": {"code": "unsafe_prune", "message": message}}
+
+
+def _coerce_size(value: Any) -> int:
+    """Convert a DSM size value to a non-negative integer byte count."""
+    if isinstance(value, bool) or value is None:
+        return 0
+    try:
+        number = Decimal(str(value).strip()) if isinstance(value, str) else Decimal(value)
+    except (InvalidOperation, TypeError, ValueError):
+        return 0
+    if not number.is_finite() or number < 0:
+        return 0
+    return int(number)
 
 from utils.synology_api import SynologyAPIClient
 
@@ -117,8 +129,10 @@ class SynologyContainer:
         result = self.list_containers(offset=0, limit=-1, container_type="all")
         if not result.get("success"):
             return result
-        data = result.get("data", {})
-        items = data.get("containers", []) if isinstance(data, dict) else []
+        data = result.get("data")
+        if not isinstance(data, dict):
+            return {"success": False, "error": {"code": "invalid_inventory", "message": "DSM returned an invalid Container Manager inventory"}}
+        items = data.get("containers", [])
         summary = [{"name": i.get("name"), "status": i.get("status", i.get("state")), "health": i.get("health"), "restart_count": i.get("restartCount", i.get("restart_count", 0)), "image": i.get("image")} for i in items if isinstance(i, dict)]
         return {"success": True, "data": {"containers": summary, "count": len(summary)}}
 
@@ -138,8 +152,8 @@ class SynologyContainer:
         container_items = container_data.get("containers")
         if not isinstance(image_items, list) or not isinstance(container_items, list):
             return {"success": False, "error": {"code": "invalid_inventory", "message": "DSM returned an invalid Container Manager inventory"}}
-        image_bytes = sum(int(item.get("size", 0) or 0) for item in image_items if isinstance(item, dict) and str(item.get("size", "")).isdigit())
-        container_bytes = sum(int(item.get("size", 0) or 0) for item in container_items if isinstance(item, dict) and str(item.get("size", "")).isdigit())
+        image_bytes = sum(_coerce_size(item.get("size")) for item in image_items if isinstance(item, dict))
+        container_bytes = sum(_coerce_size(item.get("size")) for item in container_items if isinstance(item, dict))
         return {"success": True, "data": {"mode": "api", "images": {"count": len(image_items), "size_bytes": image_bytes}, "containers": {"count": len(container_items), "size_bytes": container_bytes}, "volumes": {"supported": False}, "build_cache": {"supported": False}}}
 
     def get_container(self, name: str) -> Dict[str, Any]:

--- a/src/container/synology_container.py
+++ b/src/container/synology_container.py
@@ -5,7 +5,6 @@ import re
 from decimal import Decimal, InvalidOperation
 from typing import Any, Dict, Optional
 
-
 _IMAGE_ID_RE = re.compile(r"^(?:sha256:)?[0-9a-fA-F]{64}$")
 _DIGEST_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+._-]*:[0-9a-fA-F]{32,}$")
 
@@ -37,7 +36,12 @@ def _canonical_image_reference(reference: str) -> tuple[str, Optional[str], Opti
     )
     if not has_registry:
         components.insert(0, "docker.io")
-    if components[0] == "docker.io" and len(components) == 2:
+    registry = components[0].lower()
+    if registry == "index.docker.io":
+        # Docker treats index.docker.io as a legacy alias of docker.io.
+        components[0] = "docker.io"
+        registry = "docker.io"
+    if registry == "docker.io" and len(components) == 2:
         components.insert(1, "library")
     normalized_repository = "/".join(components).lower()
     normalized_tag = None if separator else (tag or "latest")
@@ -132,7 +136,9 @@ class SynologyContainer:
         data = result.get("data")
         if not isinstance(data, dict):
             return {"success": False, "error": {"code": "invalid_inventory", "message": "DSM returned an invalid Container Manager inventory"}}
-        items = data.get("containers", [])
+        items = data.get("containers")
+        if not isinstance(items, list):
+            return {"success": False, "error": {"code": "invalid_inventory", "message": "DSM returned an invalid Container Manager inventory"}}
         summary = [{"name": i.get("name"), "status": i.get("status", i.get("state")), "health": i.get("health"), "restart_count": i.get("restartCount", i.get("restart_count", 0)), "image": i.get("image")} for i in items if isinstance(i, dict)]
         return {"success": True, "data": {"containers": summary, "count": len(summary)}}
 

--- a/src/container/synology_container.py
+++ b/src/container/synology_container.py
@@ -1,7 +1,12 @@
 """Synology Container Manager operations."""
 
 import json
+import os
+import stat
+import subprocess
+import tempfile
 from typing import Any, Dict, Optional
+from urllib.parse import urlsplit
 
 from utils.synology_api import SynologyAPIClient
 
@@ -15,8 +20,12 @@ class SynologyContainer:
         session_id: str,
         verify_ssl: bool = False,
         syno_token: Optional[str] = None,
+        ssh_username: Optional[str] = None,
+        ssh_password: Optional[str] = None,
     ):
         self._api = SynologyAPIClient(base_url, session_id, verify_ssl, syno_token=syno_token)
+        self._ssh_username = ssh_username
+        self._ssh_password = ssh_password
         self.container_api = "SYNO.Docker.Container"
         self.container_version = 1
         self.project_api = "SYNO.Docker.Project"
@@ -291,8 +300,158 @@ class SynologyContainer:
             self.image_api,
             self.image_version,
             "delete",
-            images=json.dumps([image]),
+            name=name,
+            tag=tag,
         )
+
+    def prune_images(self) -> Dict[str, Any]:
+        """Delete images that are not referenced by any container.
+
+        Some DSM versions expose no working Docker image-prune API.  When
+        explicitly configured with SSH credentials, use Docker's image-only
+        prune command.  Otherwise use the DSM list/delete APIs and fail closed
+        if any container image reference is unavailable.
+        """
+        if self._ssh_username and self._ssh_password:
+            return self._ssh_docker_prune()
+
+        return self._prune_images_from_inventory(dry_run=False)
+
+    def preview_image_prune(self) -> Dict[str, Any]:
+        """Preview removable images without invoking SSH or mutating DSM."""
+        return self._prune_images_from_inventory(dry_run=True)
+
+    def _prune_images_from_inventory(self, dry_run: bool) -> Dict[str, Any]:
+        """Compute image-prune candidates from the DSM inventories."""
+
+        containers = self.list_containers(offset=0, limit=-1, container_type="all")
+        if not containers.get("success"):
+            return containers
+        container_data = containers.get("data", {})
+        container_items = container_data.get("containers", []) if isinstance(container_data, dict) else []
+        references = set()
+        for item in container_items:
+            if not isinstance(item, dict) or not item.get("image"):
+                return {
+                    "success": False,
+                    "error": {
+                        "code": "unsafe_prune",
+                        "message": "Cannot determine every container image reference; no images were deleted",
+                    },
+                }
+            image = str(item["image"])
+            references.add(image)
+            if "@" in image:
+                references.add(image.split("@", 1)[0])
+
+        images_result = self.list_images(offset=0, limit=-1)
+        if not images_result.get("success"):
+            return images_result
+        image_data = images_result.get("data", {})
+        images = image_data.get("images", []) if isinstance(image_data, dict) else []
+        if not isinstance(images, list):
+            return {
+                "success": False,
+                "error": {"code": "unsafe_prune", "message": "Unexpected image inventory; no images were deleted"},
+            }
+
+        candidates = []
+        skipped = []
+        for image in images:
+            if not isinstance(image, dict) or not image.get("repository"):
+                continue
+            tags = image.get("tags") or ["<none>"]
+            for tag in tags:
+                tag = str(tag)
+                full_name = f"{image['repository']}:{tag}"
+                if tag == "<none>":
+                    # DSM rejects literal <none> tags.  Leave dangling layers
+                    # for the Docker CLI fallback rather than reporting a
+                    # misleading deletion attempt.
+                    skipped.append(full_name)
+                elif full_name not in references:
+                    candidates.append((full_name, image))
+
+        if dry_run:
+            return {
+                "success": True,
+                "data": {
+                    "mode": "preview",
+                    "candidates": [name for name, _ in candidates],
+                    "skipped": skipped,
+                    "errors": [],
+                },
+            }
+
+        deleted = []
+        errors = []
+        for full_name, image in candidates:
+            repository, tag = full_name.rsplit(":", 1)
+            result = self._make_request(
+                self.image_api,
+                self.image_version,
+                "delete",
+                name=repository,
+                tag=tag,
+            )
+            if result.get("success"):
+                deleted.append(full_name)
+            else:
+                errors.append({"image": full_name, "error": result.get("error", {})})
+
+        response = {
+            "success": not errors,
+            "data": {"mode": "api", "deleted": deleted, "skipped": skipped, "errors": errors},
+        }
+        if errors:
+            response["error"] = {"code": "partial_prune", "message": "Some unused images could not be deleted"}
+        return response
+
+    def _ssh_docker_prune(self) -> Dict[str, Any]:
+        """Run Docker's image-only prune through the authorized SSH account."""
+        host = urlsplit(self._api.base_url).hostname
+        if not host:
+            return {"success": False, "error": {"code": "invalid_host", "message": "NAS URL has no hostname"}}
+
+        askpass_fd, askpass = tempfile.mkstemp(prefix="synology-mcp-askpass-")
+        os.close(askpass_fd)
+        try:
+            os.chmod(askpass, stat.S_IRWXU)
+            with open(askpass, "w", encoding="utf-8") as handle:
+                handle.write("#!/bin/sh\nprintf '%s\\n' \"$SYNOLOGY_SSH_PASSWORD\"\n")
+            env = os.environ.copy()
+            env.update({
+                "SYNOLOGY_SSH_PASSWORD": self._ssh_password,
+                "SSH_ASKPASS": askpass,
+                "SSH_ASKPASS_REQUIRE": "force",
+                "DISPLAY": "synology-mcp",
+            })
+            command = (
+                "sudo -n /var/packages/ContainerManager/target/usr/bin/docker "
+                "image prune --all --force"
+            )
+            result = subprocess.run(
+                [
+                    "setsid", "ssh", "-o", "BatchMode=no", "-o", "ConnectTimeout=20",
+                    "-o", "PreferredAuthentications=password", "-o", "PubkeyAuthentication=no",
+                    "-o", "StrictHostKeyChecking=accept-new", f"{self._ssh_username}@{host}", command,
+                ],
+                capture_output=True, text=True, timeout=300, env=env, check=False,
+            )
+        except FileNotFoundError as exc:
+            return {"success": False, "error": {"code": "ssh_unavailable", "message": str(exc)}}
+        except subprocess.TimeoutExpired:
+            return {"success": False, "error": {"code": "ssh_timeout", "message": "Docker prune timed out"}}
+        finally:
+            try:
+                os.unlink(askpass)
+            except OSError:
+                pass
+
+        output = (result.stdout or "").strip()
+        if result.returncode:
+            return {"success": False, "error": {"code": "ssh_prune_failed", "message": (result.stderr or output).strip()[-2000:]}}
+        return {"success": True, "data": {"mode": "ssh", "output": output}}
 
     def pull_image(self, repository: str, tag: str = "latest") -> Dict[str, Any]:
         """Pull a Container Manager image from a registry."""

--- a/src/container/synology_container.py
+++ b/src/container/synology_container.py
@@ -1,7 +1,52 @@
 """Synology Container Manager operations."""
 
 import json
+import re
 from typing import Any, Dict, Optional
+
+
+_IMAGE_ID_RE = re.compile(r"^(?:sha256:)?[0-9a-fA-F]{64}$")
+_DIGEST_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+._-]*:[0-9a-fA-F]{32,}$")
+
+
+def _canonical_image_reference(reference: str) -> tuple[str, Optional[str], Optional[str]]:
+    """Return Docker's normalized repository, tag, and digest components."""
+    if not isinstance(reference, str) or not reference or reference != reference.strip():
+        raise ValueError("invalid image reference")
+    if _IMAGE_ID_RE.fullmatch(reference):
+        raise ValueError("bare image ID is not an image reference")
+
+    name, separator, digest = reference.partition("@")
+    if separator and (not digest or not _DIGEST_RE.fullmatch(digest)):
+        raise ValueError("invalid image digest")
+    if "@" in digest:
+        raise ValueError("invalid image reference")
+
+    last = name.rsplit("/", 1)[-1]
+    tag = None
+    if ":" in last:
+        repository, tag = name.rsplit(":", 1)
+        if not tag:
+            raise ValueError("invalid image tag")
+    else:
+        repository = name
+    if not repository or any(not component for component in repository.split("/")):
+        raise ValueError("invalid image repository")
+
+    components = repository.split("/")
+    has_registry = len(components) > 1 and (
+        "." in components[0] or ":" in components[0] or components[0] == "localhost"
+    )
+    if not has_registry:
+        components.insert(0, "docker.io")
+    if components[0] == "docker.io" and len(components) == 2:
+        components.insert(1, "library")
+    normalized_repository = "/".join(components).lower()
+    return normalized_repository, tag or "latest" if not separator else None, digest or None
+
+
+def _unsafe_prune_result(message: str) -> Dict[str, Any]:
+    return {"success": False, "error": {"code": "unsafe_prune", "message": message}}
 
 from utils.synology_api import SynologyAPIClient
 
@@ -85,8 +130,12 @@ class SynologyContainer:
         containers = self.list_containers(offset=0, limit=-1, container_type="all")
         if not containers.get("success"):
             return containers
-        image_items = images.get("data", {}).get("images", [])
-        container_items = containers.get("data", {}).get("containers", [])
+        image_data = images.get("data")
+        container_data = containers.get("data")
+        if not isinstance(image_data, dict) or not isinstance(container_data, dict):
+            return {"success": False, "error": {"code": "invalid_inventory", "message": "DSM returned an invalid Container Manager inventory"}}
+        image_items = image_data.get("images")
+        container_items = container_data.get("containers")
         if not isinstance(image_items, list) or not isinstance(container_items, list):
             return {"success": False, "error": {"code": "invalid_inventory", "message": "DSM returned an invalid Container Manager inventory"}}
         image_bytes = sum(int(item.get("size", 0) or 0) for item in image_items if isinstance(item, dict) and str(item.get("size", "")).isdigit())
@@ -348,57 +397,36 @@ class SynologyContainer:
         references = set()
         digest_repositories = set()
         for item in container_items:
-            if not isinstance(item, dict) or not item.get("image"):
-                return {
-                    "success": False,
-                    "error": {
-                        "code": "unsafe_prune",
-                        "message": "Cannot determine every container image reference; no images were deleted",
-                    },
-                }
-            image = item["image"]
-            if not isinstance(image, str) or not image:
-                return {
-                    "success": False,
-                    "error": {
-                        "code": "unsafe_prune",
-                        "message": "Cannot determine every container image reference; no images were deleted",
-                    },
-                }
-            references.add(image)
-            if "@" in image:
-                repository = image.split("@", 1)[0]
-                # Strip an optional tag while preserving registry ports.
-                last_component = repository.rsplit("/", 1)[-1]
-                if ":" in last_component:
-                    repository = repository.rsplit(":", 1)[0]
+            if not isinstance(item, dict) or not isinstance(item.get("image"), str) or not item["image"]:
+                return _unsafe_prune_result("Cannot determine every container image reference; no images were deleted")
+            try:
+                repository, tag, digest = _canonical_image_reference(item["image"])
+            except ValueError:
+                return _unsafe_prune_result("Cannot parse every container image reference; no images were deleted")
+            if digest:
+                # DSM image inventories do not reliably expose manifest digests.
+                # Protect the whole canonical repository unless an exact digest
+                # match can be established from a future inventory shape.
                 digest_repositories.add(repository)
+            else:
+                references.add((repository, tag))
 
         images_result = self.list_images(offset=0, limit=-1)
         if not images_result.get("success"):
             return images_result
         image_data = images_result.get("data")
         if not isinstance(image_data, dict) or not isinstance(image_data.get("images"), list):
-            return {
-                "success": False,
-                "error": {"code": "unsafe_prune", "message": "Unexpected image inventory; no images were deleted"},
-            }
+            return _unsafe_prune_result("Unexpected image inventory; no images were deleted")
         images = image_data["images"]
 
         candidates = []
         skipped = []
         for image in images:
             if not isinstance(image, dict) or not isinstance(image.get("repository"), str) or not image["repository"]:
-                return {
-                    "success": False,
-                    "error": {"code": "unsafe_prune", "message": "Unexpected image inventory; no images were deleted"},
-                }
+                return _unsafe_prune_result("Unexpected image inventory; no images were deleted")
             tags = image.get("tags")
-            if not isinstance(tags, list) or any(not isinstance(tag, str) for tag in tags):
-                return {
-                    "success": False,
-                    "error": {"code": "unsafe_prune", "message": "Unexpected image inventory; no images were deleted"},
-                }
+            if not isinstance(tags, list) or any(not isinstance(tag, str) or not tag for tag in tags):
+                return _unsafe_prune_result("Unexpected image inventory; no images were deleted")
             if not tags:
                 tags = ["<none>"]
             for tag in tags:
@@ -406,15 +434,20 @@ class SynologyContainer:
                 if tag == "<none>":
                     # DSM rejects literal <none> tags; report them separately.
                     skipped.append(full_name)
-                elif full_name not in references and image["repository"] not in digest_repositories:
-                    candidates.append((full_name, image))
+                    continue
+                try:
+                    repository, candidate_tag, _ = _canonical_image_reference(f"{image['repository']}:{tag}")
+                except ValueError:
+                    return _unsafe_prune_result("Unexpected image inventory; no images were deleted")
+                if (repository, candidate_tag) not in references and repository not in digest_repositories:
+                    candidates.append((full_name, image["repository"], tag))
 
         if dry_run:
             return {
                 "success": True,
                 "data": {
                     "mode": "preview",
-                    "candidates": [name for name, _ in candidates],
+                    "candidates": [name for name, _, _ in candidates],
                     "skipped": skipped,
                     "errors": [],
                 },
@@ -422,8 +455,7 @@ class SynologyContainer:
 
         deleted = []
         errors = []
-        for full_name, image in candidates:
-            repository, tag = full_name.rsplit(":", 1)
+        for full_name, repository, tag in candidates:
             result = self._make_request(
                 self.image_api,
                 self.image_version,

--- a/src/container/synology_container.py
+++ b/src/container/synology_container.py
@@ -356,35 +356,55 @@ class SynologyContainer:
                         "message": "Cannot determine every container image reference; no images were deleted",
                     },
                 }
-            image = str(item["image"])
+            image = item["image"]
+            if not isinstance(image, str) or not image:
+                return {
+                    "success": False,
+                    "error": {
+                        "code": "unsafe_prune",
+                        "message": "Cannot determine every container image reference; no images were deleted",
+                    },
+                }
             references.add(image)
             if "@" in image:
-                digest_repositories.add(image.split("@", 1)[0])
+                repository = image.split("@", 1)[0]
+                # Strip an optional tag while preserving registry ports.
+                last_component = repository.rsplit("/", 1)[-1]
+                if ":" in last_component:
+                    repository = repository.rsplit(":", 1)[0]
+                digest_repositories.add(repository)
 
         images_result = self.list_images(offset=0, limit=-1)
         if not images_result.get("success"):
             return images_result
-        image_data = images_result.get("data", {})
-        images = image_data.get("images", []) if isinstance(image_data, dict) else []
-        if not isinstance(images, list):
+        image_data = images_result.get("data")
+        if not isinstance(image_data, dict) or not isinstance(image_data.get("images"), list):
             return {
                 "success": False,
                 "error": {"code": "unsafe_prune", "message": "Unexpected image inventory; no images were deleted"},
             }
+        images = image_data["images"]
 
         candidates = []
         skipped = []
         for image in images:
-            if not isinstance(image, dict) or not image.get("repository"):
-                continue
-            tags = image.get("tags") or ["<none>"]
+            if not isinstance(image, dict) or not isinstance(image.get("repository"), str) or not image["repository"]:
+                return {
+                    "success": False,
+                    "error": {"code": "unsafe_prune", "message": "Unexpected image inventory; no images were deleted"},
+                }
+            tags = image.get("tags")
+            if not isinstance(tags, list) or any(not isinstance(tag, str) for tag in tags):
+                return {
+                    "success": False,
+                    "error": {"code": "unsafe_prune", "message": "Unexpected image inventory; no images were deleted"},
+                }
+            if not tags:
+                tags = ["<none>"]
             for tag in tags:
-                tag = str(tag)
                 full_name = f"{image['repository']}:{tag}"
                 if tag == "<none>":
-                    # DSM rejects literal <none> tags.  Leave dangling layers
-                    # for the Docker CLI fallback rather than reporting a
-                    # misleading deletion attempt.
+                    # DSM rejects literal <none> tags; report them separately.
                     skipped.append(full_name)
                 elif full_name not in references and image["repository"] not in digest_repositories:
                     candidates.append((full_name, image))

--- a/src/container/synology_container.py
+++ b/src/container/synology_container.py
@@ -1,12 +1,7 @@
 """Synology Container Manager operations."""
 
 import json
-import os
-import stat
-import subprocess
-import tempfile
 from typing import Any, Dict, Optional
-from urllib.parse import urlsplit
 
 from utils.synology_api import SynologyAPIClient
 
@@ -20,14 +15,10 @@ class SynologyContainer:
         session_id: str,
         verify_ssl: bool = False,
         syno_token: Optional[str] = None,
-        ssh_username: Optional[str] = None,
-        ssh_password: Optional[str] = None,
-        ssh_known_hosts: Optional[str] = None,
+
     ):
         self._api = SynologyAPIClient(base_url, session_id, verify_ssl, syno_token=syno_token)
-        self._ssh_username = ssh_username
-        self._ssh_password = ssh_password
-        self._ssh_known_hosts = ssh_known_hosts
+
         self.container_api = "SYNO.Docker.Container"
         self.container_version = 1
         self.project_api = "SYNO.Docker.Project"
@@ -87,8 +78,20 @@ class SynologyContainer:
         return {"success": True, "data": {"containers": summary, "count": len(summary)}}
 
     def disk_usage(self) -> Dict[str, Any]:
-        """Return Docker disk usage using the read-only SSH CLI."""
-        return self._ssh_docker_command("system df", "docker_disk_usage_failed", "Docker disk usage timed out")
+        """Return a read-only disk-usage summary from DSM Container Manager APIs."""
+        images = self.list_images(offset=0, limit=-1, show_dsm=False)
+        if not images.get("success"):
+            return images
+        containers = self.list_containers(offset=0, limit=-1, container_type="all")
+        if not containers.get("success"):
+            return containers
+        image_items = images.get("data", {}).get("images", [])
+        container_items = containers.get("data", {}).get("containers", [])
+        if not isinstance(image_items, list) or not isinstance(container_items, list):
+            return {"success": False, "error": {"code": "invalid_inventory", "message": "DSM returned an invalid Container Manager inventory"}}
+        image_bytes = sum(int(item.get("size", 0) or 0) for item in image_items if isinstance(item, dict) and str(item.get("size", "")).isdigit())
+        container_bytes = sum(int(item.get("size", 0) or 0) for item in container_items if isinstance(item, dict) and str(item.get("size", "")).isdigit())
+        return {"success": True, "data": {"mode": "api", "images": {"count": len(image_items), "size_bytes": image_bytes}, "containers": {"count": len(container_items), "size_bytes": container_bytes}, "volumes": {"supported": False}, "build_cache": {"supported": False}}}
 
     def get_container(self, name: str) -> Dict[str, Any]:
         """Get one Container Manager container by name."""
@@ -323,18 +326,13 @@ class SynologyContainer:
     def prune_images(self) -> Dict[str, Any]:
         """Delete images that are not referenced by any container.
 
-        Some DSM versions expose no working Docker image-prune API.  When
-        explicitly configured with SSH credentials, use Docker's image-only
-        prune command.  Otherwise use the DSM list/delete APIs and fail closed
-        if any container image reference is unavailable.
+        Uses DSM list/delete APIs and fails closed if any container image
+        reference is unavailable.
         """
-        if self._ssh_username and self._ssh_password:
-            return self._ssh_docker_prune()
-
         return self._prune_images_from_inventory(dry_run=False)
 
     def preview_image_prune(self) -> Dict[str, Any]:
-        """Preview removable images without invoking SSH or mutating DSM."""
+        """Preview removable images without mutating DSM."""
         return self._prune_images_from_inventory(dry_run=True)
 
     def _prune_images_from_inventory(self, dry_run: bool) -> Dict[str, Any]:
@@ -426,63 +424,6 @@ class SynologyContainer:
             response["error"] = {"code": "partial_prune", "message": "Some unused images could not be deleted"}
         return response
 
-    def _ssh_docker_prune(self) -> Dict[str, Any]:
-        """Run Docker's image-only prune through the authorized SSH account."""
-        return self._ssh_docker_command("image prune --all --force", "ssh_prune_failed", "Docker prune timed out")
-
-    def _ssh_docker_command(self, docker_command: str, error_code: str, timeout_message: str) -> Dict[str, Any]:
-        """Run a fixed Docker command through the explicitly configured SSH account."""
-        host = urlsplit(self._api.base_url).hostname
-        if not host:
-            return {"success": False, "error": {"code": "invalid_host", "message": "NAS URL has no hostname"}}
-        if not self._ssh_username or not self._ssh_password:
-            return {"success": False, "error": {"code": "ssh_credentials_unavailable", "message": "Explicit SSH credentials are required"}}
-        if not self._ssh_known_hosts:
-            return {"success": False, "error": {"code": "ssh_known_hosts_unavailable", "message": "A provisioned SSH known_hosts file is required"}}
-
-
-        if docker_command not in {"image prune --all --force", "system df"}:
-            return {"success": False, "error": {"code": "unsupported_ssh_command", "message": "Unsupported Docker command"}}
-
-        askpass_fd, askpass = tempfile.mkstemp(prefix="synology-mcp-askpass-")
-        os.close(askpass_fd)
-        try:
-            os.chmod(askpass, stat.S_IRWXU)
-            with open(askpass, "w", encoding="utf-8") as handle:
-                handle.write("#!/bin/sh\nprintf '%s\\n' \"$SYNOLOGY_SSH_PASSWORD\"\n")
-            env = os.environ.copy()
-            env.update({
-                "SYNOLOGY_SSH_PASSWORD": self._ssh_password,
-                "SSH_ASKPASS": askpass,
-                "SSH_ASKPASS_REQUIRE": "force",
-                "DISPLAY": "synology-mcp",
-            })
-            command = "sudo -n /var/packages/ContainerManager/target/usr/bin/docker " + docker_command
-            result = subprocess.run(
-                [
-                    "/usr/bin/setsid", "/usr/bin/ssh", "-o", "BatchMode=no", "-o", "ConnectTimeout=20",
-                    "-o", "PreferredAuthentications=password", "-o", "PubkeyAuthentication=no",
-                    "-o", "StrictHostKeyChecking=yes", "-o", f"UserKnownHostsFile={self._ssh_known_hosts}", f"{self._ssh_username}@{host}", command,
-                ],
-                capture_output=True, text=True, timeout=300, env=env, check=False,
-            )
-        except FileNotFoundError as exc:
-            return {"success": False, "error": {"code": "ssh_unavailable", "message": str(exc)}}
-        except subprocess.TimeoutExpired:
-            return {"success": False, "error": {"code": "ssh_timeout", "message": timeout_message}}
-        finally:
-            try:
-                os.unlink(askpass)
-            except OSError:
-                pass
-
-        output = (result.stdout or "").strip()
-        if result.returncode:
-            return {"success": False, "error": {"code": error_code, "message": (result.stderr or output).strip()[-2000:]}}
-        data = {"mode": "ssh", "output": output}
-        if docker_command == "system df":
-            data["command"] = docker_command
-        return {"success": True, "data": data}
 
     def pull_image(self, repository: str, tag: str = "latest") -> Dict[str, Any]:
         """Pull a Container Manager image from a registry."""

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -444,9 +444,7 @@ class SynologyMCPServer:
                 session_id,
                 verify_ssl=config.verify_ssl_for(base_url),
                 syno_token=self.syno_tokens.get(base_url),
-                ssh_username=config.ssh_credentials_for(base_url)[0],
-                ssh_password=config.ssh_credentials_for(base_url)[1],
-                ssh_known_hosts=config.ssh_credentials_for(base_url)[2],
+
             )
 
         return self.container_instances[base_url]

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -236,6 +236,8 @@ class SynologyMCPServer:
         self._register_tool("synology_container_image_list", "List Docker images", CI, partial(self._handle_container_call, method_name="image_list"))
         self._register_tool("synology_container_image_get", "Get details of a specific Docker image", CI | {"properties": {**CI["properties"], "name": {"type": "string", "description": "Image repository name (e.g. \'nginx\')"}, "tag": {"type": "string", "description": "Image tag (default: latest)"}}, "required": ["name"]}, partial(self._handle_container_call, method_name="image_get"))
         self._register_tool("synology_container_image_delete", "Delete a Docker image", CI | {"properties": {**CI["properties"], "name": {"type": "string", "description": "Image repository name (e.g. \'nginx\')"}, "tag": {"type": "string", "description": "Image tag (default: latest)"}}, "required": ["name"]}, partial(self._handle_container_call, method_name="image_delete"))
+        self._register_tool("synology_container_image_prune_preview", "Preview unused Docker images without deleting anything", CI, partial(self._handle_container_call, method_name="image_prune_preview"))
+        self._register_tool("synology_container_image_prune", "Remove Docker images unused by any container; preserves containers, networks, and build cache", CI, partial(self._handle_container_call, method_name="image_prune"))
         self._register_tool("synology_container_image_pull", "Pull a Docker image from a registry", CI | {"properties": {**CI["properties"], "repository": {"type": "string", "description": "Image repository name (e.g. \'nginx\')"}, "tag": {"type": "string", "description": "Image tag (default: latest)"}}}, partial(self._handle_container_call, method_name="image_pull"))
         self._register_tool("synology_container_registry_list", "List configured Docker registries", CI, partial(self._handle_container_call, method_name="registry_list"))
         self._register_tool("synology_container_registry_search", "Search for images in a Docker registry", CI | {"properties": {**CI["properties"], "query": {"type": "string", "description": "Search query for image name"}, "offset": {"type": "integer", "description": "Pagination offset (default: 0)"}, "limit": {"type": "integer", "description": "Max results to return (default: 50)"}}, "required": ["query"]}, partial(self._handle_container_call, method_name="registry_search"))
@@ -440,6 +442,8 @@ class SynologyMCPServer:
                 session_id,
                 verify_ssl=config.verify_ssl_for(base_url),
                 syno_token=self.syno_tokens.get(base_url),
+                ssh_username=config.credentials_for(base_url)[0],
+                ssh_password=config.credentials_for(base_url)[1],
             )
 
         return self.container_instances[base_url]
@@ -1195,6 +1199,10 @@ class SynologyMCPServer:
                 limit=arguments.get("limit", -1),
                 show_dsm=arguments.get("show_dsm", False),
             )
+        elif method_name == "image_prune":
+            result = container.prune_images()
+        elif method_name == "image_prune_preview":
+            result = container.preview_image_prune()
         elif method_name in {"image_get", "image_delete"}:
             image_method = {
                 "image_get": container.get_image,

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -442,8 +442,9 @@ class SynologyMCPServer:
                 session_id,
                 verify_ssl=config.verify_ssl_for(base_url),
                 syno_token=self.syno_tokens.get(base_url),
-                ssh_username=config.credentials_for(base_url)[0],
-                ssh_password=config.credentials_for(base_url)[1],
+                ssh_username=config.ssh_credentials_for(base_url)[0],
+                ssh_password=config.ssh_credentials_for(base_url)[1],
+                ssh_known_hosts=config.ssh_credentials_for(base_url)[2],
             )
 
         return self.container_instances[base_url]

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -216,6 +216,8 @@ class SynologyMCPServer:
             "required": [],
         }
         self._register_tool("synology_container_list", "List Container Manager containers", CI | {"properties": {**CI["properties"], "offset": {"type": "integer", "description": "Pagination offset"}, "limit": {"type": "integer", "description": "Maximum containers to return"}, "container_type": {"type": "string", "description": "Container filter (default: all)"}}}, partial(self._handle_container_call, method_name="list"))
+        self._register_tool("synology_container_health_summary", "Summarize container status, health, restart counts, and images", CI, partial(self._handle_container_call, method_name="health_summary"))
+        self._register_tool("synology_container_disk_usage", "Show Docker disk usage without changing anything", CI, partial(self._handle_container_call, method_name="disk_usage"))
         self._register_tool("synology_container_get", "Get detailed information about a specific container", CI | {"properties": {**CI["properties"], "name": {"type": "string", "description": "Container name (e.g. \'watchtower\')"}}, "required": ["name"]}, partial(self._handle_container_call, method_name="get"))
         self._register_tool("synology_container_start", "Start a container", CI | {"properties": {**CI["properties"], "name": {"type": "string", "description": "Container name (e.g. \'watchtower\')"}}, "required": ["name"]}, partial(self._handle_container_call, method_name="start"))
         self._register_tool("synology_container_stop", "Stop a running container", CI | {"properties": {**CI["properties"], "name": {"type": "string", "description": "Container name (e.g. \'watchtower\')"}}, "required": ["name"]}, partial(self._handle_container_call, method_name="stop"))
@@ -1171,6 +1173,10 @@ class SynologyMCPServer:
                 limit=arguments.get("limit", -1),
                 container_type=arguments.get("container_type", "all"),
             )
+        elif method_name == "health_summary":
+            result = container.health_summary()
+        elif method_name == "disk_usage":
+            result = container.disk_usage()
         elif method_name == "project_list":
             result = container.list_projects()
         elif method_name == "project_create":

--- a/tests/test_container_manager.py
+++ b/tests/test_container_manager.py
@@ -436,6 +436,22 @@ def test_image_prune_canonicalizes_implicit_latest_and_library_aliases():
     assert result["data"]["candidates"] == ["nginx:old", "redis:7"]
 
 
+def test_image_prune_normalizes_legacy_index_docker_io_alias():
+    """index.docker.io and docker.io references protect the same images."""
+    container = _container()
+    with patch.object(
+        container,
+        "list_containers",
+        return_value={"success": True, "data": {"containers": [{"image": "index.docker.io/library/nginx:latest"}]}},
+    ), patch.object(
+        container,
+        "list_images",
+        return_value={"success": True, "data": {"images": [{"repository": "nginx", "tags": ["latest"]}]}},
+    ):
+        result = container.preview_image_prune()
+    assert result["data"]["candidates"] == []
+
+
 @pytest.mark.parametrize("reference", ["sha256:" + "a" * 64, "nginx:", "nginx@sha256:not-a-digest"])
 def test_image_prune_fails_closed_on_bare_or_unparseable_container_reference(reference):
     container = _container()
@@ -888,6 +904,15 @@ def test_container_disk_usage_coerces_numeric_sizes(
 def test_container_health_summary_rejects_non_dictionary_inventory_payload():
     container = _container()
     with patch.object(container, "list_containers", return_value={"success": True, "data": None}):
+        result = container.health_summary()
+    assert result["success"] is False
+    assert result["error"]["code"] == "invalid_inventory"
+
+
+@pytest.mark.parametrize("containers", [None, "running", {"name": "plex"}])
+def test_container_health_summary_rejects_non_list_containers_field(containers):
+    container = _container()
+    with patch.object(container, "list_containers", return_value={"success": True, "data": {"containers": containers}}):
         result = container.health_summary()
     assert result["success"] is False
     assert result["error"]["code"] == "invalid_inventory"

--- a/tests/test_container_manager.py
+++ b/tests/test_container_manager.py
@@ -395,11 +395,49 @@ def test_image_prune_protects_digest_referenced_repository():
     assert result["data"]["candidates"] == []
 
 
-def test_image_prune_fails_closed_on_malformed_container_inventory():
-    from container.synology_container import SynologyContainer
+def test_image_prune_protects_digest_repository_with_registry_port_and_tag():
+    """Digest references protect all tags while preserving registry ports."""
+    container = _container()
+    with patch.object(
+        container,
+        "list_containers",
+        return_value={"success": True, "data": {"containers": [{"image": "registry.example:5000/nginx:stable@sha256:abc"}]}},
+    ), patch.object(
+        container,
+        "list_images",
+        return_value={
+            "success": True,
+            "data": {"images": [{"repository": "registry.example:5000/nginx", "tags": ["stable", "old"]}]},
+        },
+    ):
+        result = container.preview_image_prune()
+    assert result["data"]["candidates"] == []
 
-    container = SynologyContainer("https://nas.example.com:5001", "sid_xyz")
-    with patch.object(container, "list_containers", return_value={"success": True, "data": {}}), patch.object(container, "list_images") as images:
+
+def test_image_prune_fails_closed_on_malformed_image_inventory():
+    """Malformed image records never result in deletion requests."""
+    container = _container()
+    with patch.object(
+        container,
+        "list_containers",
+        return_value={"success": True, "data": {"containers": []}},
+    ), patch.object(
+        container,
+        "list_images",
+        return_value={"success": True, "data": {"images": [{"repository": "nginx", "tags": "latest"}]}},
+    ), patch.object(container, "_make_request") as request:
+        result = container.prune_images()
+    assert result["success"] is False
+    assert result["error"]["code"] == "unsafe_prune"
+    request.assert_not_called()
+
+
+def test_image_prune_fails_closed_on_malformed_container_inventory():
+    """Malformed container inventories stop pruning before image lookup."""
+    container = _container()
+    with patch.object(container, "list_containers", return_value={"success": True, "data": {}}), patch.object(
+        container, "list_images"
+    ) as images:
         result = container.preview_image_prune()
     assert result["success"] is False
     assert result["error"]["code"] == "unsafe_prune"

--- a/tests/test_container_manager.py
+++ b/tests/test_container_manager.py
@@ -359,6 +359,7 @@ def test_image_prune_ssh_fallback_uses_image_only_command():
         "sid_xyz",
         ssh_username="sshuser",
         ssh_password="sshpass",
+        ssh_known_hosts="/tmp/known_hosts",
     )
     completed = MagicMock(returncode=0, stdout="Total reclaimed space: 1GB", stderr="")
 
@@ -372,6 +373,8 @@ def test_image_prune_ssh_fallback_uses_image_only_command():
     command = run.call_args.args[0]
     assert command[-1] == "sudo -n /var/packages/ContainerManager/target/usr/bin/docker image prune --all --force"
     assert "system prune" not in command[-1]
+    assert "StrictHostKeyChecking=yes" in command
+    assert "UserKnownHostsFile=/tmp/known_hosts" in command
 
 
 def test_image_prune_preview_is_read_only_and_reports_candidates():
@@ -406,6 +409,36 @@ def test_image_prune_preview_is_read_only_and_reports_candidates():
     list_containers.assert_called_once()
     list_images.assert_called_once()
     request.assert_not_called()
+
+
+def test_image_prune_protects_digest_referenced_repository():
+    from container.synology_container import SynologyContainer
+
+    container = SynologyContainer("https://nas.example.com:5001", "sid_xyz")
+    with patch.object(container, "list_containers", return_value={"success": True, "data": {"containers": [{"image": "nginx@sha256:abc"}]}}), patch.object(
+        container, "list_images", return_value={"success": True, "data": {"images": [{"repository": "nginx", "tags": ["latest", "old"]}]}}
+    ):
+        result = container.preview_image_prune()
+    assert result["data"]["candidates"] == []
+
+
+def test_image_prune_fails_closed_on_malformed_container_inventory():
+    from container.synology_container import SynologyContainer
+
+    container = SynologyContainer("https://nas.example.com:5001", "sid_xyz")
+    with patch.object(container, "list_containers", return_value={"success": True, "data": {}}), patch.object(container, "list_images") as images:
+        result = container.preview_image_prune()
+    assert result["success"] is False
+    assert result["error"]["code"] == "unsafe_prune"
+    images.assert_not_called()
+
+
+def test_image_prune_ssh_requires_explicit_known_hosts():
+    from container.synology_container import SynologyContainer
+
+    container = SynologyContainer("https://nas.example.com:5001", "sid_xyz", ssh_username="user", ssh_password="pass")
+    result = container.prune_images()
+    assert result["error"]["code"] == "ssh_known_hosts_unavailable"
 
 
 def test_image_prune_fails_closed_when_container_references_are_missing():

--- a/tests/test_container_manager.py
+++ b/tests/test_container_manager.py
@@ -454,6 +454,36 @@ def test_image_prune_fails_closed_on_bare_or_unparseable_container_reference(ref
     request.assert_not_called()
 
 
+def test_image_prune_reports_partial_deletion_results():
+    container = _container()
+    with patch.object(
+        container,
+        "list_containers",
+        return_value={"success": True, "data": {"containers": []}},
+    ), patch.object(
+        container,
+        "list_images",
+        return_value={
+            "success": True,
+            "data": {"images": [{"repository": "nginx", "tags": ["old", "older"]}]},
+        },
+    ), patch.object(
+        container,
+        "_make_request",
+        side_effect=[
+            {"success": False, "error": {"code": "delete_failed", "message": "busy"}},
+            {"success": True},
+        ],
+    ) as request:
+        result = container.prune_images()
+
+    assert result["success"] is False
+    assert result["error"] == {"code": "partial_prune", "message": "Some unused images could not be deleted"}
+    assert result["data"]["deleted"] == ["nginx:older"]
+    assert result["data"]["errors"] == [{"image": "nginx:old", "error": {"code": "delete_failed", "message": "busy"}}]
+    assert request.call_count == 2
+
+
 def test_image_prune_fails_closed_on_malformed_image_inventory():
     """Malformed image records never result in deletion requests."""
     container = _container()
@@ -830,11 +860,34 @@ def test_container_disk_usage_rejects_non_dictionary_container_payload():
     assert result["error"]["code"] == "invalid_inventory"
 
 
-def test_container_disk_usage_rejects_non_dictionary_inventory_payloads():
+@pytest.mark.parametrize(
+    ("image_sizes", "container_sizes", "expected_images", "expected_containers"),
+    [
+        ([100, "20", "1.5", True, -3, "invalid"], ["4.5", False, None], 121, 4),
+    ],
+)
+def test_container_disk_usage_coerces_numeric_sizes(
+    image_sizes, container_sizes, expected_images, expected_containers
+):
     container = _container()
-    with patch.object(container, "list_images", return_value={"success": True, "data": []}), patch.object(
-        container, "list_containers", return_value={"success": True, "data": {"containers": []}}
+    with patch.object(
+        container,
+        "list_images",
+        return_value={"success": True, "data": {"images": [{"size": size} for size in image_sizes]}},
+    ), patch.object(
+        container,
+        "list_containers",
+        return_value={"success": True, "data": {"containers": [{"size": size} for size in container_sizes]}},
     ):
         result = container.disk_usage()
+
+    assert result["data"]["images"]["size_bytes"] == expected_images
+    assert result["data"]["containers"]["size_bytes"] == expected_containers
+
+
+def test_container_health_summary_rejects_non_dictionary_inventory_payload():
+    container = _container()
+    with patch.object(container, "list_containers", return_value={"success": True, "data": None}):
+        result = container.health_summary()
     assert result["success"] is False
     assert result["error"]["code"] == "invalid_inventory"

--- a/tests/test_container_manager.py
+++ b/tests/test_container_manager.py
@@ -350,33 +350,6 @@ def test_image_prune_removes_only_unreferenced_images():
     assert request.call_args.kwargs == {"name": "nginx", "tag": "latest"}
 
 
-def test_image_prune_ssh_fallback_uses_image_only_command():
-    """The SSH fallback preserves stopped containers and networks."""
-    from container.synology_container import SynologyContainer
-
-    container = SynologyContainer(
-        "https://nas.example.com:5001",
-        "sid_xyz",
-        ssh_username="sshuser",
-        ssh_password="sshpass",
-        ssh_known_hosts="/tmp/known_hosts",
-    )
-    completed = MagicMock(returncode=0, stdout="Total reclaimed space: 1GB", stderr="")
-
-    with patch("container.synology_container.subprocess.run", return_value=completed) as run:
-        result = container.prune_images()
-
-    assert result == {
-        "success": True,
-        "data": {"mode": "ssh", "output": "Total reclaimed space: 1GB"},
-    }
-    command = run.call_args.args[0]
-    assert command[-1] == "sudo -n /var/packages/ContainerManager/target/usr/bin/docker image prune --all --force"
-    assert "system prune" not in command[-1]
-    assert "StrictHostKeyChecking=yes" in command
-    assert "UserKnownHostsFile=/tmp/known_hosts" in command
-
-
 def test_image_prune_preview_is_read_only_and_reports_candidates():
     from container.synology_container import SynologyContainer
 
@@ -431,14 +404,6 @@ def test_image_prune_fails_closed_on_malformed_container_inventory():
     assert result["success"] is False
     assert result["error"]["code"] == "unsafe_prune"
     images.assert_not_called()
-
-
-def test_image_prune_ssh_requires_explicit_known_hosts():
-    from container.synology_container import SynologyContainer
-
-    container = SynologyContainer("https://nas.example.com:5001", "sid_xyz", ssh_username="user", ssh_password="pass")
-    result = container.prune_images()
-    assert result["error"]["code"] == "ssh_known_hosts_unavailable"
 
 
 def test_image_prune_fails_closed_when_container_references_are_missing():
@@ -739,14 +704,13 @@ def test_container_health_summary_is_compact_and_read_only():
         assert container.health_summary() == {"success": True, "data": {"count": 1, "containers": [{"name": "plex", "status": "running", "health": "healthy", "restart_count": 2, "image": "plex:latest"}]}}
 
 
-def test_container_disk_usage_uses_read_only_docker_command():
+def test_container_disk_usage_uses_read_only_api_calls():
     container = _container()
-    container._ssh_username = "sshuser"
-    container._ssh_password = "sshpass"
-    container._ssh_known_hosts = "/tmp/known_hosts"
-    completed = MagicMock(returncode=0, stdout="Images space usage:\n", stderr="")
-    with patch("container.synology_container.subprocess.run", return_value=completed) as run:
+    with patch.object(container, "list_images", return_value={"success": True, "data": {"images": [{"size": 100}]}}), patch.object(
+        container, "list_containers", return_value={"success": True, "data": {"containers": [{"size": 20}]}}
+    ):
         result = container.disk_usage()
     assert result["success"] is True
-    assert result["data"]["command"] == "system df"
-    assert "prune" not in run.call_args.args[0][-1]
+    assert result["data"]["mode"] == "api"
+    assert result["data"]["images"]["size_bytes"] == 100
+    assert result["data"]["containers"]["size_bytes"] == 20

--- a/tests/test_container_manager.py
+++ b/tests/test_container_manager.py
@@ -388,7 +388,7 @@ def test_image_prune_protects_digest_referenced_repository():
     from container.synology_container import SynologyContainer
 
     container = SynologyContainer("https://nas.example.com:5001", "sid_xyz")
-    with patch.object(container, "list_containers", return_value={"success": True, "data": {"containers": [{"image": "nginx@sha256:abc"}]}}), patch.object(
+    with patch.object(container, "list_containers", return_value={"success": True, "data": {"containers": [{"image": "nginx@sha256:" + "a" * 64}]}}), patch.object(
         container, "list_images", return_value={"success": True, "data": {"images": [{"repository": "nginx", "tags": ["latest", "old"]}]}}
     ):
         result = container.preview_image_prune()
@@ -401,7 +401,7 @@ def test_image_prune_protects_digest_repository_with_registry_port_and_tag():
     with patch.object(
         container,
         "list_containers",
-        return_value={"success": True, "data": {"containers": [{"image": "registry.example:5000/nginx:stable@sha256:abc"}]}},
+        return_value={"success": True, "data": {"containers": [{"image": "registry.example:5000/nginx:stable@sha256:" + "b" * 64}]}},
     ), patch.object(
         container,
         "list_images",
@@ -412,6 +412,46 @@ def test_image_prune_protects_digest_repository_with_registry_port_and_tag():
     ):
         result = container.preview_image_prune()
     assert result["data"]["candidates"] == []
+
+
+def test_image_prune_canonicalizes_implicit_latest_and_library_aliases():
+    container = _container()
+    with patch.object(
+        container,
+        "list_containers",
+        return_value={"success": True, "data": {"containers": [{"image": "docker.io/library/nginx:latest"}, {"image": "busybox"}]}},
+    ), patch.object(
+        container,
+        "list_images",
+        return_value={
+            "success": True,
+            "data": {"images": [
+                {"repository": "nginx", "tags": ["latest", "old"]},
+                {"repository": "docker.io/library/busybox", "tags": ["latest"]},
+                {"repository": "redis", "tags": ["7"]},
+            ]},
+        },
+    ):
+        result = container.preview_image_prune()
+    assert result["data"]["candidates"] == ["nginx:old", "redis:7"]
+
+
+@pytest.mark.parametrize("reference", ["sha256:" + "a" * 64, "nginx:", "nginx@sha256:not-a-digest"])
+def test_image_prune_fails_closed_on_bare_or_unparseable_container_reference(reference):
+    container = _container()
+    with patch.object(
+        container,
+        "list_containers",
+        return_value={"success": True, "data": {"containers": [{"image": reference}]}},
+    ), patch.object(
+        container,
+        "list_images",
+        return_value={"success": True, "data": {"images": [{"repository": "nginx", "tags": ["latest"]}]}},
+    ), patch.object(container, "_make_request") as request:
+        result = container.prune_images()
+    assert result["success"] is False
+    assert result["error"]["code"] == "unsafe_prune"
+    request.assert_not_called()
 
 
 def test_image_prune_fails_closed_on_malformed_image_inventory():
@@ -693,6 +733,9 @@ def test_container_tools_are_registered():
         "synology_container_image_get",
         "synology_container_image_delete",
         "synology_container_image_prune",
+        "synology_container_image_prune_preview",
+        "synology_container_health_summary",
+        "synology_container_disk_usage",
         "synology_container_image_pull",
         "synology_container_registry_list",
         "synology_container_registry_search",
@@ -752,3 +795,46 @@ def test_container_disk_usage_uses_read_only_api_calls():
     assert result["data"]["mode"] == "api"
     assert result["data"]["images"]["size_bytes"] == 100
     assert result["data"]["containers"]["size_bytes"] == 20
+
+
+def test_container_disk_usage_rejects_null_inventory_payloads():
+    container = _container()
+    with patch.object(container, "list_images", return_value={"success": True, "data": None}), patch.object(
+        container, "list_containers", return_value={"success": True, "data": None}
+    ):
+        result = container.disk_usage()
+    assert result == {
+        "success": False,
+        "error": {"code": "invalid_inventory", "message": "DSM returned an invalid Container Manager inventory"},
+    }
+
+
+@pytest.mark.parametrize("payload", [None, []])
+def test_container_disk_usage_rejects_non_dictionary_image_payloads(payload):
+    container = _container()
+    with patch.object(container, "list_images", return_value={"success": True, "data": payload}), patch.object(
+        container, "list_containers", return_value={"success": True, "data": {"containers": []}}
+    ):
+        result = container.disk_usage()
+    assert result["success"] is False
+    assert result["error"]["code"] == "invalid_inventory"
+
+
+def test_container_disk_usage_rejects_non_dictionary_container_payload():
+    container = _container()
+    with patch.object(container, "list_images", return_value={"success": True, "data": {"images": []}}), patch.object(
+        container, "list_containers", return_value={"success": True, "data": None}
+    ):
+        result = container.disk_usage()
+    assert result["success"] is False
+    assert result["error"]["code"] == "invalid_inventory"
+
+
+def test_container_disk_usage_rejects_non_dictionary_inventory_payloads():
+    container = _container()
+    with patch.object(container, "list_images", return_value={"success": True, "data": []}), patch.object(
+        container, "list_containers", return_value={"success": True, "data": {"containers": []}}
+    ):
+        result = container.disk_usage()
+    assert result["success"] is False
+    assert result["error"]["code"] == "invalid_inventory"

--- a/tests/test_container_manager.py
+++ b/tests/test_container_manager.py
@@ -310,6 +310,123 @@ def test_project_id_lookup_tolerates_non_dict_data(data):
     assert result["error"]["code"] == "not_found"
 
 
+def test_image_prune_removes_only_unreferenced_images():
+    """Pruning preserves container image references and deletes the rest."""
+    container = _container()
+
+    with patch.object(
+        container,
+        "list_containers",
+        return_value={
+            "success": True,
+            "data": {"containers": [{"image": "caddy:alpine"}]},
+        },
+    ), patch.object(
+        container,
+        "list_images",
+        return_value={
+            "success": True,
+            "data": {
+                "images": [
+                    {"id": "sha256:used", "repository": "caddy", "tags": ["alpine"]},
+                    {"id": "sha256:unused", "repository": "nginx", "tags": ["latest"]},
+                    {"id": "sha256:dangling", "repository": "caddy", "tags": ["<none>"]},
+                ]
+            },
+        },
+    ), patch.object(
+        container,
+        "_make_request",
+        return_value={"success": True},
+    ) as request:
+        result = container.prune_images()
+
+    assert result["success"] is True
+    assert result["data"]["mode"] == "api"
+    assert result["data"]["deleted"] == ["nginx:latest"]
+    assert result["data"]["skipped"] == ["caddy:<none>"]
+    assert request.call_count == 1
+    assert request.call_args.args == ("SYNO.Docker.Image", 1, "delete")
+    assert request.call_args.kwargs == {"name": "nginx", "tag": "latest"}
+
+
+def test_image_prune_ssh_fallback_uses_image_only_command():
+    """The SSH fallback preserves stopped containers and networks."""
+    from container.synology_container import SynologyContainer
+
+    container = SynologyContainer(
+        "https://nas.example.com:5001",
+        "sid_xyz",
+        ssh_username="sshuser",
+        ssh_password="sshpass",
+    )
+    completed = MagicMock(returncode=0, stdout="Total reclaimed space: 1GB", stderr="")
+
+    with patch("container.synology_container.subprocess.run", return_value=completed) as run:
+        result = container.prune_images()
+
+    assert result == {
+        "success": True,
+        "data": {"mode": "ssh", "output": "Total reclaimed space: 1GB"},
+    }
+    command = run.call_args.args[0]
+    assert command[-1] == "sudo -n /var/packages/ContainerManager/target/usr/bin/docker image prune --all --force"
+    assert "system prune" not in command[-1]
+
+
+def test_image_prune_preview_is_read_only_and_reports_candidates():
+    from container.synology_container import SynologyContainer
+
+    container = SynologyContainer("https://nas.example.com:5001", "sid_xyz")
+    containers = {"success": True, "data": {"containers": [{"image": "nginx:latest"}]}}
+    images = {
+        "success": True,
+        "data": {
+            "images": [
+                {"repository": "nginx", "tags": ["latest"]},
+                {"repository": "caddy", "tags": ["alpine"]},
+                {"repository": "dangling", "tags": ["<none>"]},
+            ]
+        },
+    }
+    with patch.object(container, "list_containers", return_value=containers) as list_containers, patch.object(
+        container, "list_images", return_value=images
+    ) as list_images, patch.object(container, "_make_request") as request:
+        result = container.preview_image_prune()
+
+    assert result == {
+        "success": True,
+        "data": {
+            "mode": "preview",
+            "candidates": ["caddy:alpine"],
+            "skipped": ["dangling:<none>"],
+            "errors": [],
+        },
+    }
+    list_containers.assert_called_once()
+    list_images.assert_called_once()
+    request.assert_not_called()
+
+
+def test_image_prune_fails_closed_when_container_references_are_missing():
+    """Pruning never deletes images when the container inventory is incomplete."""
+    container = _container()
+
+    with patch.object(
+        container,
+        "list_containers",
+        return_value={"success": True, "data": {"containers": [{"name": "broken"}]}},
+    ), patch.object(
+        container,
+        "list_images",
+        return_value={"success": True, "data": {"images": [{"repository": "nginx", "tags": ["latest"]}]}},
+    ):
+        result = container.prune_images()
+
+    assert result["success"] is False
+    assert result["error"]["code"] == "unsafe_prune"
+
+
 def test_image_methods_wire_format_matches_dsm():
     """Image tools expose local image list/get/delete and pull."""
     container = _container()
@@ -360,11 +477,9 @@ def test_image_methods_wire_format_matches_dsm():
 
     delete_data = post.call_args_list[3].kwargs["data"]
     assert delete_data["method"] == "delete"
-    assert json.loads(delete_data["images"]) == [
-        {"id": "sha256:caddy", "repository": "caddy", "tags": ["alpine"]}
-    ]
-    assert "name" not in delete_data
-    assert "tag" not in delete_data
+    assert delete_data["name"] == "caddy"
+    assert delete_data["tag"] == "alpine"
+    assert "images" not in delete_data
 
     pull_data = post.call_args_list[4].kwargs["data"]
     assert pull_data["method"] == "pull_start"
@@ -541,6 +656,7 @@ def test_container_tools_are_registered():
         "synology_container_image_list",
         "synology_container_image_get",
         "synology_container_image_delete",
+        "synology_container_image_prune",
         "synology_container_image_pull",
         "synology_container_registry_list",
         "synology_container_registry_search",

--- a/tests/test_container_manager.py
+++ b/tests/test_container_manager.py
@@ -731,3 +731,19 @@ async def test_legacy_single_nas_auto_login_registers_default_name():
         await server._auto_login_if_configured()
 
     assert server.nas_name_map["default"] == "http://nas.example.com:5000"
+
+
+def test_container_health_summary_is_compact_and_read_only():
+    container = _container()
+    with patch.object(container, "list_containers", return_value={"success": True, "data": {"containers": [{"name": "plex", "status": "running", "health": "healthy", "restartCount": 2, "image": "plex:latest"}]}}):
+        assert container.health_summary() == {"success": True, "data": {"count": 1, "containers": [{"name": "plex", "status": "running", "health": "healthy", "restart_count": 2, "image": "plex:latest"}]}}
+
+
+def test_container_disk_usage_uses_read_only_docker_command():
+    container = _container()
+    completed = MagicMock(returncode=0, stdout="Images space usage:\n", stderr="")
+    with patch("container.synology_container.subprocess.run", return_value=completed) as run:
+        result = container.disk_usage()
+    assert result["success"] is True
+    assert result["data"]["command"] == "system df"
+    assert "prune" not in run.call_args.args[0][-1]

--- a/tests/test_container_manager.py
+++ b/tests/test_container_manager.py
@@ -741,6 +741,9 @@ def test_container_health_summary_is_compact_and_read_only():
 
 def test_container_disk_usage_uses_read_only_docker_command():
     container = _container()
+    container._ssh_username = "sshuser"
+    container._ssh_password = "sshpass"
+    container._ssh_known_hosts = "/tmp/known_hosts"
     completed = MagicMock(returncode=0, stdout="Images space usage:\n", stderr="")
     with patch("container.synology_container.subprocess.run", return_value=completed) as run:
         result = container.disk_usage()


### PR DESCRIPTION
## Summary
- Add compact container health and read-only disk-usage summaries.
- Add `synology_container_image_prune_preview`, a read-only inventory-based preview.
- Add `synology_container_image_prune` using only DSM Container Manager APIs.
- Keep cleanup image-only: containers, networks, and build cache are preserved.
- Fail closed on incomplete or malformed inventories.
- Protect all tags for repositories referenced by immutable digest, including registry ports and explicit tags.
- Report dangling `<none>` images that DSM cannot safely delete.

## Safety
The preview and disk-usage operations are read-only. Prune reads complete DSM inventories before deleting tagged candidates individually; it never invokes SSH or broad Docker cleanup. Preview results are advisory and may change before cleanup.

## Verification
Focused container-manager tests, compilation, and whitespace checks are run on every fix commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added read-only container health summaries and disk-usage reporting.
  * Added image-pruning preview and cleanup tools for unused Docker images.
  * Cleanup preserves containers, networks, build cache, and referenced images.
  * Preview reports removable, protected, and unremovable images without making changes.
  * Added an optional SSH-based cleanup fallback when standard pruning is unavailable.
* **Documentation**
  * Updated the README and changelog with container inspection and image-pruning capabilities.
* **Bug Fixes**
  * Improved reporting for failed or partial image cleanup results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->