### PR TITLE
docs(skill): correct user and NFS tool parameters in the bundled skill

### DIFF
--- a/skills/synology-nas/references/shares-nfs.md
+++ b/skills/synology-nas/references/shares-nfs.md
@@ -88,7 +88,7 @@ sudo mount -t nfs <nas-ip>:/volume1/Photos /mnt/photos -o ro,nfsvers=4
 
 Use a CIDR string for `client_ip`:
 
-```
+```text
 synology_nfs_set_permission(
   share_name="backups",
   client_ip="192.168.1.0/24",

--- a/skills/synology-nas/references/shares-nfs.md
+++ b/skills/synology-nas/references/shares-nfs.md
@@ -4,11 +4,11 @@
 
 | Tool | Purpose | Required |
 |------|---------|----------|
-| `synology_create_share` | Create a new shared folder | `share_name` |
+| `synology_create_share` | Create a new shared folder | `share_name`, `vol_path` |
 | `synology_nfs_status` | NFS service status & config | — |
-| `synology_nfs_enable` | Enable/disable the NFS service | `enabled` |
+| `synology_nfs_enable` | Enable/disable the NFS service | — (`enable`, default `true`) |
 | `synology_nfs_list_shares` | List shares with their NFS export rules | — |
-| `synology_nfs_set_permission` | Set NFS access for a host on a share | `share_name`, `client` rules |
+| `synology_nfs_set_permission` | Set NFS access for a client on a share | `share_name`, `client_ip` |
 
 All accept `nas_name` / `base_url`.
 
@@ -23,28 +23,31 @@ If the user says "create a share" or "add a new share", they want `synology_crea
 ## Creating a share
 
 ```
-synology_create_share(share_name="projects", description="Engineering projects")
+synology_create_share(
+  share_name="projects",
+  vol_path="/volume1",
+  description="Engineering projects",
+)
 ```
 
-Common optional fields: location (which volume), encryption, quota. Surface DSM's response — it includes the new share's path.
+`share_name` and `vol_path` are both required — `vol_path` is the volume the share lands on (`/volume1`, `/volume2`, …). Optional fields: `description`, `enable_recycle_bin` (default `true`), `recycle_bin_admin_only` (default `true`). Surface DSM's response — it includes the new share's path.
 
 ## NFS workflow
 
 Most users won't use NFS unless they're mounting the NAS from Linux, macOS, or another NAS. The flow:
 
 1. **Check status**: `synology_nfs_status` — is the service even on?
-2. **Enable if needed**: `synology_nfs_enable(enabled=true)`. Idempotent — calling on an already-enabled service is harmless.
+2. **Enable if needed**: `synology_nfs_enable(enable=true)`. Idempotent — calling on an already-enabled service is harmless. Pass `nfs_v4=true` (default `false`) if the client needs NFSv4.
 3. **List shares**: `synology_nfs_list_shares` — see what's currently exported and to which clients.
 4. **Set permission**: `synology_nfs_set_permission` to add/modify a client rule on a specific share.
 
 ### NFS permission shape
 
-A permission rule binds a share to a client (host or subnet) with a privilege set:
+A permission rule binds a share to a client — `client_ip`, a single host or a CIDR subnet (`'10.0.0.5'`, `'192.168.1.0/24'`) — with a privilege set:
 
-- **Privilege**: `rw` (read-write), `ro` (read-only), or `no_access`.
-- **Squash**: `no_mapping`, `root_squash` (default — root mapped to nobody), `all_squash` (everyone mapped to nobody), `map_user_to_admin`. Default is `root_squash` — only override if the user has a specific reason (e.g., admin-mapped backups).
-- **Security**: `sys` (default), `krb5`, `krb5i`, `krb5p` if Kerberos is configured. Stick with `sys` unless the user mentions Kerberos.
-- **Async / sync**: async is faster, sync is safer for transactional writes.
+- **`privilege`**: `readwrite` (default) or `readonly`. There is no deny value — to take away a client's NFS access you delete its rule in DSM (Control Panel → Shared Folder → Edit → NFS Permissions), not by setting a "no access" privilege here.
+- **`squash`**: `root_squash` (default — root mapped to nobody), `no_root_squash` (root on the client keeps root on the NAS), `all_squash` (everyone mapped to nobody). Only override the default if the user has a specific reason (e.g., a client that must write as root).
+- **`security`**: `sys` (default), `krb5`, `krb5i`, `krb5p` if Kerberos is configured. Stick with `sys` unless the user mentions Kerberos.
 
 When in doubt, mirror what's already exported on a similar share — `synology_nfs_list_shares` shows existing rules.
 
@@ -68,8 +71,8 @@ Earlier MCP versions had bugs creating shares on DSM 7.3.2 (additional-param enc
 synology_nfs_status                                  # confirm enabled
 synology_nfs_set_permission(
   share_name="Photos",
-  client="192.168.1.50",
-  privilege="ro",
+  client_ip="192.168.1.50",
+  privilege="readonly",
   squash="root_squash",
   security="sys",
 )
@@ -83,13 +86,13 @@ sudo mount -t nfs <nas-ip>:/volume1/Photos /mnt/photos -o ro,nfsvers=4
 
 ### "Open NFS access to the whole subnet"
 
-Use a CIDR client string:
+Use a CIDR string for `client_ip`:
 
 ```
 synology_nfs_set_permission(
   share_name="backups",
-  client="192.168.1.0/24",
-  privilege="rw",
+  client_ip="192.168.1.0/24",
+  privilege="readwrite",
   squash="root_squash",
 )
 ```
@@ -99,7 +102,11 @@ Confirm with the user before opening RW to a whole subnet — it's a meaningful 
 ### "Create a new share for project files"
 
 ```
-synology_create_share(share_name="projects-2026", description="2026 project work")
+synology_create_share(
+  share_name="projects-2026",
+  vol_path="/volume1",
+  description="2026 project work",
+)
 ```
 
 If the user wants NFS on it too, follow up with `synology_nfs_set_permission`.

--- a/skills/synology-nas/references/users.md
+++ b/skills/synology-nas/references/users.md
@@ -43,7 +43,7 @@ The README warns against running the MCP as a primary admin account. If user-man
 
 ### When error 105 comes back
 
-Error 105 is DSM's "the logged in session does not have permission". Report it and stop — don't retry with a different password, a different group, or a tweaked parameter name; no argument change will turn a privilege verdict around. Route the user to DSM Control Panel → User & Group to do the work by hand.
+Error 105 is DSM's "the logged-in session does not have permission". Report it and stop — don't retry with a different password, a different group, or a tweaked parameter name; no argument change will turn a privilege verdict around. Route the user to DSM Control Panel → User & Group to do the work by hand.
 
 Don't read 105 into every failed write, though — DSM returns distinct codes for distinct causes, and the ones that look like permission failures often aren't. Verified on DSM 7.3.2-86009 Update 4 with an account in `administrators`:
 

--- a/skills/synology-nas/references/users.md
+++ b/skills/synology-nas/references/users.md
@@ -132,7 +132,7 @@ synology_add_user_to_group(              # groups are a separate call
 )
 synology_set_user_permissions(
   name="photographer",
-  permissions=[{"name": "Photos", "is_writable": False}]
+  permissions=[{"name": "Photos", "is_writable": false}]
 )
 ```
 

--- a/skills/synology-nas/references/users.md
+++ b/skills/synology-nas/references/users.md
@@ -43,7 +43,18 @@ The README warns against running the MCP as a primary admin account. If user-man
 
 ### When error 105 comes back
 
-Error 105 is DSM's "the logged in session does not have permission". Report it and stop — don't retry with a different password, a different group, or a tweaked parameter name. A `synology_delete_user` against a user that doesn't exist returns 105 too, so the code says nothing about the arguments you sent; it's the session's privilege on that method. Route the user to DSM Control Panel → User & Group to do the work by hand.
+Error 105 is DSM's "the logged in session does not have permission". Report it and stop — don't retry with a different password, a different group, or a tweaked parameter name; no argument change will turn a privilege verdict around. Route the user to DSM Control Panel → User & Group to do the work by hand.
+
+Don't read 105 into every failed write, though — DSM returns distinct codes for distinct causes, and the ones that look like permission failures often aren't. Verified on DSM 7.3.2-86009 Update 4 with an account in `administrators`:
+
+| Call | Condition | Code |
+|------|-----------|------|
+| `synology_delete_user` | username doesn't exist | `3101` |
+| `synology_get_user` | username doesn't exist | `3106` |
+
+Both mean "no such user" — the argument is wrong, not the privileges. Read the code that actually came back before concluding anything: 105 is a privilege verdict, `3101` and `3106` are not.
+
+Don't generalize in either direction from a single session. Mutating `SYNO.Core.User` calls have been observed returning 105 on this DSM version with an admin-group account, and later re-testing over the same MCP process, same account, could not reproduce it — `create` and `delete` both succeeded. The trigger for the earlier refusals isn't understood. So report a 105 and stop, as above, but don't assume from one clean run that writes can never be refused.
 
 ## Read before write
 

--- a/skills/synology-nas/references/users.md
+++ b/skills/synology-nas/references/users.md
@@ -18,11 +18,32 @@
 
 All accept `nas_name` / `base_url`.
 
+### Identifier parameter — `name` vs `username`
+
+The tools are **inconsistent** about what the user-identifier parameter is called. Getting this wrong is a schema validation error, not a silent no-op:
+
+| Tool | Identifier param |
+|------|------------------|
+| `synology_get_user` | `name` |
+| `synology_create_user` | `name` |
+| `synology_set_user` | `name` (plus `new_name` to rename) |
+| `synology_delete_user` | `name` |
+| `synology_get_user_permissions` | `name` |
+| `synology_set_user_permissions` | `name` |
+| `synology_add_user_to_group` | **`username`** |
+| `synology_remove_user_from_group` | **`username`** |
+
+The two group-membership tools are the exception — they take `username`, everything else takes `name`. `synology_list_group_members` takes `group` (not `group_name`).
+
 ## When to use this domain
 
 User management is **admin-level**. The MCP must be authenticated as a user with admin rights for these calls to succeed. If the user is connecting with a non-admin account (recommended for safety), most of these tools will fail with permission errors — surface that clearly rather than retrying.
 
 The README warns against running the MCP as a primary admin account. If user-management actions are needed, the user should temporarily authenticate with an admin account, do the work, and switch back. Don't try to elevate from inside Claude.
+
+### When error 105 comes back
+
+Error 105 is DSM's "the logged in session does not have permission". Report it and stop — don't retry with a different password, a different group, or a tweaked parameter name. A `synology_delete_user` against a user that doesn't exist returns 105 too, so the code says nothing about the arguments you sent; it's the session's privilege on that method. Route the user to DSM Control Panel → User & Group to do the work by hand.
 
 ## Read before write
 
@@ -36,28 +57,41 @@ DSM's user model is additive (group membership grants permissions, plus per-user
 
 ### Creating a new user
 
-`synology_create_user` requires at minimum a name and password. Common optional fields:
+`synology_create_user` requires `name` and `password`. The complete set of accepted fields:
 
+- `name` — username (required).
+- `password` — required.
 - `email` — for password recovery and notifications.
 - `description` — surface this when listing users.
-- `groups` — initial group memberships. Common groups: `users`, `administrators`, `http`.
-- `expired` — account expiry date.
-- `password_never_expire` — boolean.
+- `cannot_chg_passwd` — boolean, default `false`.
+- `passwd_never_expire` — boolean, default `true`. (Note the abbreviated `passwd`, not `password`.)
+- `nas_name` / `base_url`.
 
-For most setups: create with `groups: ["users"]` and add to additional groups via `synology_add_user_to_group` afterward. Putting someone in `administrators` is a meaningful trust decision — confirm before doing it.
+**There is no `groups` parameter on `synology_create_user`.** Group membership is a separate call — create the user first, then `synology_add_user_to_group(username=..., groups=[...])`. Putting someone in `administrators` is a meaningful trust decision — confirm before doing it.
+
+To disable an account, use `synology_set_user(name=..., expired="now")`; `"normal"` re-enables it. `expired` is an enum on `set_user`, not a date, and it does not exist on `create_user`.
 
 ### Setting share permissions
 
-`synology_set_user_permissions` controls per-share access (read, write, none). Permission entries look like:
+`synology_set_user_permissions(name=..., permissions=[...])` controls per-share access. Each permission entry is:
 
 ```json
 {
-  "share_name": "Photos",
-  "permission": "rw"  // or "ro", "no_access"
+  "name": "Photos",
+  "is_writable": true,
+  "is_deny": false
 }
 ```
 
-Pass an array of entries; not-mentioned shares retain their existing permission. To revoke access, set `"permission": "no_access"` explicitly — don't just omit the share.
+Only `name` (the shared folder name) is required per entry; `is_writable` and `is_deny` are booleans. There is no `share_name` key and no `"rw"`/`"ro"`/`"no_access"` string values — that grammar is:
+
+| Intent | Entry |
+|--------|-------|
+| Read/write | `{"name": "Photos", "is_writable": true}` |
+| Read-only | `{"name": "Photos", "is_writable": false}` |
+| Deny | `{"name": "Photos", "is_deny": true}` |
+
+Pass an array of entries; not-mentioned shares retain their existing permission. To revoke access, send an explicit `is_deny: true` entry — don't just omit the share.
 
 ### Deleting users
 
@@ -77,28 +111,31 @@ Pass an array of entries; not-mentioned shares retain their existing permission.
 
 ```
 synology_create_user(
-  username="photographer",
+  name="photographer",
   password="<strong-pass>",
   description="Read-only photo access",
+)
+synology_add_user_to_group(              # groups are a separate call
+  username="photographer",
   groups=["users"],
 )
 synology_set_user_permissions(
-  username="photographer",
-  permissions=[{"share_name": "Photos", "permission": "ro"}]
+  name="photographer",
+  permissions=[{"name": "Photos", "is_writable": False}]
 )
 ```
 
 ### "Who's in the administrators group?"
 
 ```
-synology_list_group_members(group_name="administrators")
+synology_list_group_members(group="administrators")
 ```
 
 ### "Remove user 'temp-contractor'"
 
 ```
-synology_get_user(username="temp-contractor")        # confirm it's the right one
-synology_delete_user(username="temp-contractor")     # permanent
+synology_get_user(name="temp-contractor")            # confirm it's the right one
+synology_delete_user(name="temp-contractor")         # permanent
 # optionally:
 delete(path="/homes/temp-contractor")                # cleanup home dir
 ```


### PR DESCRIPTION
Fixes the parameter-name half of #88 — the bundled skill's reference docs named parameters the tools don't accept, so a client that follows them fails on the first call with a schema validation error instead of reaching the NAS.

Every field was checked against the tool schemas emitted by `src/mcp_server.py` at the commit this branches from (dumped `tools/list` from a local stdio run, rather than trusting a running install that might be a different build).

**`references/users.md`**

- Six user tools take `name`, not `username`. `add_user_to_group` and `remove_user_from_group` are the exceptions that really do take `username` — documented as a table rather than silently fixing the call sites, since the split is easy to trip over in either direction.
- `list_group_members` takes `group`, not `group_name`.
- `create_user` has no `groups` parameter. The old "create with `groups: ["users"]`" workflow couldn't work; group membership is a separate `add_user_to_group` call, and the worked example now shows that.
- `passwd_never_expire`, not `password_never_expire`.
- `expired` is a `"normal"|"now"` enum on `set_user`, not an expiry date on `create_user`.
- `set_user_permissions` entries are `{name, is_writable, is_deny}` booleans, not `{share_name, permission}` with `"rw"`/`"ro"`/`"no_access"` strings.

**`references/shares-nfs.md`**

- `create_share` also requires `vol_path`; documented the optional `description` / `enable_recycle_bin` / `recycle_bin_admin_only`.
- `nfs_enable` takes `enable` (plus `nfs_v4`), not `enabled`.
- `nfs_set_permission` takes `client_ip`, not `client`.
- `privilege` is `readonly`|`readwrite` — there's no deny value, so revoking access means deleting the rule in DSM.
- `squash` is `root_squash` | `no_root_squash` | `all_squash`; the documented `no_mapping` and `map_user_to_admin` don't exist, and `no_root_squash` was missing.
- Dropped the async/sync bullet — the tool exposes no such option.

Docs only; no code paths touched. The other two defects in #88 (group writes reporting `success: true` without confirming the async task applied, and `list_group_members` omitting non-user members) are left alone here since they're behavioural and you may want to fix them differently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Synology share and NFS guidance for current parameters and permission values.
  * Added CIDR support details and updated squash, security, and usage examples.
  * Clarified when to use `name` versus `username` for user and group operations.
  * Documented permission/session error 105 and separate handling for missing users.
  * Updated user creation, account disabling, group membership, and share-permission workflows.
  * Clarified that share creation requires a volume path and group membership is configured separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->