### PR TITLE
chore: ignore local agent tooling workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -254,3 +254,9 @@ scratch_*.py
 *.zip
 *.rar
 *.7z 
+
+# Local agent tooling workspaces (skills, plans) — machine-local, not project config
+.agents/
+.zcode/
+.claude/skills/
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

`.agents/`, `.zcode/`, and `.claude/skills/` are machine-local scratch directories created by agent tooling (installed skills, generated plan docs). They were showing up as untracked noise in every `git status`, so this adds them to `.gitignore`.

## Details

- `.agents/` — locally installed agent skills
- `.zcode/` — generated plan documents
- `.claude/skills/` — locally installed Claude Code skills
- `.claude/settings.local.json` — per-machine settings

Scoped to `.claude/skills/` rather than all of `.claude/` so the directory stays available for repo-level config we may want to commit later.

## Test plan

- `git check-ignore -v` confirms all three directories are matched
- `git status --porcelain` is clean on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)