### PR TITLE
Document the native Streamable HTTP transport in the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@
 
 ### Changed
 - `search_files` documents DSM's actual matching rule: `pattern` is a case-insensitive **substring** of the entry name, and wildcards are not special (`*.dcm`, `dcm` and `*dcm*` all return the same entries). The tool description previously advertised glob-style wildcards.
-- Removed `requirements.txt` and `requirements-http.txt`; `pyproject.toml` is now the single source of truth for dependencies. Test dependencies moved to the `test` extra (`pip install ".[test]"`), and the Docker image installs the project with `pip install .`. The dead `INSTALL_HTTP` build arg (a no-op since `mcp>=2.0.0` bundled uvicorn) is gone, and stale `mcp-proxy` references in the README's HTTP deployment section now match the native Streamable HTTP setup.
+- The README's remote-deployment section documents the transport the server actually runs. It still described an `mcp-proxy` sidecar wrapping `main.py` over stdio and a `/sse` connector URL, but the server has served native Streamable HTTP from uvicorn at `MCP_HTTP_PATH` (default `/mcp`) since `docker-compose.http.yml` moved off the proxy. The security note now says plainly that there is no application-level authentication, and that the `MCP_HTTP_ALLOWED_HOSTS`/`MCP_HTTP_ALLOWED_ORIGINS` DNS-rebinding allowlist is not a substitute for it.
+- Removed `requirements.txt` and `requirements-http.txt`; `pyproject.toml` is now the single source of truth for dependencies. Test dependencies moved to the `test` extra (`pip install ".[test]"`), and the Docker image installs the project with `pip install .`. The dead `INSTALL_HTTP` build arg (a no-op since `mcp>=2.0.0` bundled uvicorn) is gone.
 
 ## [1.5.0] - 2026-06-27
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ docker compose -f docker-compose.http.yml up -d --build
 docker logs -f synology-mcp-http
 ```
 
-You should see uvicorn report `Uvicorn running on http://0.0.0.0:8765` and the auto-login succeed.
+You should see the server log `Starting Streamable HTTP MCP server on http://0.0.0.0:8765/mcp` and the auto-login succeed. uvicorn's own `Uvicorn running on …` banner is *not* printed at the compose file's defaults — it is INFO on the `uvicorn.error` logger, which the server pins to `warning` unless `DEBUG=true`.
 
 ### Reverse proxy
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ If you prefer not to use Docker:
 ```
 ## 🌐 Remote Streamable HTTP Deployment
 
-By default the server speaks **stdio**, which means the MCP client has to spawn the process locally (or via a bridge such as SSH/docker exec). For setups where the NAS is remote (different machine from where Claude/Cursor runs), set `MCP_HTTP=true` and the server serves **native Streamable HTTP** (MCP 2.0) from uvicorn in the same process — no `mcp-proxy` sidecar and no separate `/sse` endpoint. This makes it consumable by any MCP client that supports URL-based connectors — exactly like `ha-mcp` or other "remote" MCP servers.
+By default the server speaks **stdio**, which means the MCP client has to spawn the process locally (or via a bridge such as SSH/docker exec). For setups where the NAS is remote (different machine from where Claude/Cursor runs), set `MCP_HTTP=true` and the server serves **native Streamable HTTP** from uvicorn in the same process — no `mcp-proxy` sidecar and no separate `/sse` endpoint. This makes it consumable by any MCP client that supports URL-based connectors — exactly like `ha-mcp` or other "remote" MCP servers.
 
 ### Architecture
 
@@ -218,7 +218,7 @@ Most MCP clients require HTTPS, so the HTTP endpoint must be fronted by a TLS-te
 
 - **Source**: `HTTPS`, hostname `synology-mcp.example.com`, port `443`
 - **Destination**: `HTTP`, `localhost`, port `8765`
-- **Custom Headers**: click *Create → WebSocket* (adds the headers needed for the long-lived streaming responses Streamable HTTP uses)
+- **Custom Headers**: none required — Streamable HTTP is plain POST/GET on a single endpoint, not a WebSocket upgrade. The *Create → WebSocket* preset is harmless if you already apply it elsewhere (it sets `Connection: upgrade` only for real upgrade requests), but it is not what keeps a stream open
 
 For Nginx, the equivalent is:
 
@@ -230,7 +230,7 @@ location / {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
-    # Streamable HTTP replies stream as long-lived text/event-stream responses
+    # Responses may stream as long-lived text/event-stream
     proxy_buffering off;
     proxy_cache off;
     proxy_read_timeout 24h;
@@ -249,7 +249,7 @@ The path is whatever `MCP_HTTP_PATH` is set to (default `/mcp`). No `command`, n
 
 ### Security
 
-The server does **not** implement any application-level authentication — anything that can reach the HTTP endpoint can call every tool. It does enable the MCP SDK's DNS-rebinding protection, which rejects requests whose `Host`/`Origin` headers are not on an allowlist (`MCP_HTTP_ALLOWED_HOSTS` / `MCP_HTTP_ALLOWED_ORIGINS`, defaulting to loopback — set both to your public domain when running behind a reverse proxy). That guards browsers against rebinding attacks; it is **not** authentication. Mitigations:
+The server does **not** implement any application-level authentication — anything that can reach the HTTP endpoint can call every tool. It does enable the MCP SDK's DNS-rebinding protection, which rejects requests whose `Host`/`Origin` headers are not on an allowlist (`MCP_HTTP_ALLOWED_HOSTS` / `MCP_HTTP_ALLOWED_ORIGINS`, defaulting to loopback). Behind a reverse proxy set both, minding the differing formats — hosts are bare (`synology-mcp.example.com`), origins are scheme-qualified (`https://synology-mcp.example.com`), as in the commented examples in `docker-compose.http.yml`. That guards browsers against rebinding attacks; it is **not** authentication. Mitigations:
 
 - Keep it on a private network or behind a VPN
 - Leave the published port on loopback (`docker-compose.http.yml` binds `127.0.0.1:8765`) so only a same-host reverse proxy can reach it

--- a/README.md
+++ b/README.md
@@ -177,9 +177,9 @@ If you prefer not to use Docker:
   }
 }
 ```
-## 🌐 Remote HTTP/SSE Deployment (NEW)
+## 🌐 Remote Streamable HTTP Deployment
 
-By default the server speaks **stdio**, which means the MCP client has to spawn the process locally (or via a bridge such as SSH/docker exec). For setups where the NAS is remote (different machine from where Claude/Cursor runs), you can expose the MCP server over **HTTP/SSE** using [`mcp-proxy`](https://github.com/sparfenyuk/mcp-proxy). This makes it consumable by any MCP client that supports URL-based connectors — exactly like `ha-mcp` or other "remote" MCP servers.
+By default the server speaks **stdio**, which means the MCP client has to spawn the process locally (or via a bridge such as SSH/docker exec). For setups where the NAS is remote (different machine from where Claude/Cursor runs), set `MCP_HTTP=true` and the server serves **native Streamable HTTP** (MCP 2.0) from uvicorn in the same process — no `mcp-proxy` sidecar and no separate `/sse` endpoint. This makes it consumable by any MCP client that supports URL-based connectors — exactly like `ha-mcp` or other "remote" MCP servers.
 
 ### Architecture
 
@@ -193,8 +193,8 @@ By default the server speaks **stdio**, which means the MCP client has to spawn 
         │ HTTP localhost:8765
         ▼
 [Docker container]
-  └─ mcp-proxy
-       └─ python main.py (stdio)
+  └─ python main.py
+       └─ uvicorn → Streamable HTTP at /mcp
 ```
 
 ### Deploy
@@ -218,7 +218,7 @@ Most MCP clients require HTTPS, so the HTTP endpoint must be fronted by a TLS-te
 
 - **Source**: `HTTPS`, hostname `synology-mcp.example.com`, port `443`
 - **Destination**: `HTTP`, `localhost`, port `8765`
-- **Custom Headers**: click *Create → WebSocket* (adds the headers needed for SSE/long-lived connections)
+- **Custom Headers**: click *Create → WebSocket* (adds the headers needed for the long-lived streaming responses Streamable HTTP uses)
 
 For Nginx, the equivalent is:
 
@@ -230,7 +230,7 @@ location / {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
-    # SSE-specific
+    # Streamable HTTP replies stream as long-lived text/event-stream responses
     proxy_buffering off;
     proxy_cache off;
     proxy_read_timeout 24h;
@@ -242,16 +242,17 @@ location / {
 In Claude Desktop (or any MCP client that supports remote connectors), add a custom connector pointing at:
 
 ```
-https://synology-mcp.example.com/sse
+https://synology-mcp.example.com/mcp
 ```
 
-No `command`, no `args`, no local Python — just a URL.
+The path is whatever `MCP_HTTP_PATH` is set to (default `/mcp`). No `command`, no `args`, no local Python — just a URL.
 
 ### Security
 
-`mcp-proxy` does **not** provide server-side authentication. Anything that can reach the HTTP endpoint can call every tool. Mitigations:
+The server does **not** implement any application-level authentication — anything that can reach the HTTP endpoint can call every tool. It does enable the MCP SDK's DNS-rebinding protection, which rejects requests whose `Host`/`Origin` headers are not on an allowlist (`MCP_HTTP_ALLOWED_HOSTS` / `MCP_HTTP_ALLOWED_ORIGINS`, defaulting to loopback — set both to your public domain when running behind a reverse proxy). That guards browsers against rebinding attacks; it is **not** authentication. Mitigations:
 
 - Keep it on a private network or behind a VPN
+- Leave the published port on loopback (`docker-compose.http.yml` binds `127.0.0.1:8765`) so only a same-host reverse proxy can reach it
 - Use the reverse proxy to enforce an IP allow-list
 - Add Basic Auth / mTLS / OAuth2 proxy at the reverse proxy layer
 - Use a dedicated low-privilege DSM user (already recommended in the security warning above)


### PR DESCRIPTION
## Why

The README's remote-deployment section described a transport the server stopped using. It documented an `mcp-proxy` sidecar wrapping `main.py` over stdio, and told users to point their MCP client at `https://…/sse`. Since `docker-compose.http.yml` moved to the native transport, `main.py` serves **Streamable HTTP** from uvicorn in-process at `MCP_HTTP_PATH` (default `/mcp`) — a user following the README would configure a connector against an endpoint that does not exist.

Follow-up to #92, which claimed in its CHANGELOG entry that this had already been done. It had only updated the two dependency sentences in the Deploy step.

## What changed

- **Intro + architecture diagram** — `mcp-proxy → python main.py (stdio)` becomes `python main.py → uvicorn → Streamable HTTP at /mcp`, gated on `MCP_HTTP=true`.
- **Client connector URL** — `/sse` → `/mcp`, noting the path follows `MCP_HTTP_PATH`.
- **Security section** — previously said "`mcp-proxy` does not provide server-side authentication", attributing the gap to a component that is no longer there. It now states that *the server* implements no application-level authentication, and describes the DNS-rebinding allowlist (`MCP_HTTP_ALLOWED_HOSTS` / `MCP_HTTP_ALLOWED_ORIGINS`, defaulting to loopback) as a browser-attack guard rather than a substitute for auth. Adds a mitigation bullet for the loopback-only port binding the compose file already does.
- **Reverse-proxy notes** — "SSE-specific" reworded to name the long-lived `text/event-stream` responses Streamable HTTP actually sends. The nginx directives themselves are unchanged and still correct.
- **CHANGELOG** — drops the overclaim from #92's entry and adds an accurate entry for this change.

## Verification

Every statement checked against source, not inferred:

- `MCP_HTTP` / `MCP_HTTP_HOST` / `MCP_HTTP_PORT` / `MCP_HTTP_PATH` defaults — `src/config.py:84-87` (`/mcp`, `8765`, `127.0.0.1`).
- Native transport, no SSE mount — `src/mcp_server.py:1448` calls `streamable_http_app(streamable_http_path=config.http_path, …)` and serves it with `uvicorn.Server`; there is no `sse_app`/`sse_path` anywhere in the tree.
- DNS-rebinding allowlist and its loopback default — `src/mcp_server.py:1437-1446`.
- Loopback port publishing — `docker-compose.http.yml:59` (`127.0.0.1:8765:8765`).
- No remaining stale references: the sole surviving `mcp-proxy`/`/sse` mention in README.md is the deliberate negation in the intro sentence.
- Heading renamed from "Remote HTTP/SSE Deployment (NEW)"; grepped the repo for links to the old anchor — none. The `HTTP/SSE` wording in CHANGELOG 1.3/1.4 entries is left alone, since those record what shipped at the time.
- README code fences balanced (48 markers).

Docs-only; no code paths touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated deployment guidance for native Streamable HTTP at `/mcp`, including direct uvicorn serving and streaming behavior.
  - Replaced outdated `/sse` and WebSocket-header instructions.
  - Expanded security guidance for loopback binding, DNS-rebinding protection, and host/origin allowlists.
  - Documented the absence of application-level authentication.
  - Updated installation instructions to use `pyproject.toml`, the `test` extra, and `pip install .`.
  - Removed obsolete proxy, build, and installation references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->